### PR TITLE
Chore/data api

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,18 @@ To use, you will need access to the AWS platform as well as the database credent
 **Queries**
 
 ```sql
-select events.created_at from events join requests on requests.id = events.request_id where requests.id = {id_here} and events.event_code = 'request-apply-success';
+-- Count of clients in draft
+select count(*) from requests where status='draft';
+
+-- Count of clients awaiting approval (note: currently auto-approve but will apply when bceid is added)
 select count(*) from requests where status='submitted';
+
+-- Count of clients completed
+select count(*) from requests where status='applied';
+
+-- Time request was initially submitted
+select events.created_at from events join requests on requests.id = events.request_id where requests.id=1 and events.event_code = 'request-pr-success' order by events.created_at asc limit 1;
+
+-- (initial )time request was fulfilled (dev, test, and prod)
+select events.created_at from events join requests on requests.id = events.request_id where requests.id={id_here} and events.event_code = 'request-apply-success';
 ```

--- a/README.md
+++ b/README.md
@@ -133,3 +133,20 @@ For the first time running the tests, the database will need to be created.
 Run `./setup.sh ssodb` from the `/db` directory to initialize it _Note: you may need to run `chmod +x` to give necessary permissions_.
 To provide the local database connection string, in your console run `export DATABASE_URL=postgresql://localhost:5432/ssodb`.
 Then running `yarn test` from the lambda directory will run the necessary migrations and test suites.
+
+## Reporting
+
+For now, reporting information can be gathered directly from the AWS Data API.
+To use, you will need access to the AWS platform as well as the database credentials.
+
+- In the AWS console, navigate to the `RDS` dashboard and select DB Clusters from the resources panel.
+- Select `aurora-db-postgres`. From the top right `actions` dropdown select query.
+- You will be prompted for the db host, db name, username and password. Enter these and select `connect` (it may take some time to connect)
+- From the saved queries, select the one you would like to use (refer to descriptions for information)
+
+**Queries**
+
+```sql
+select events.created_at from events join requests on requests.id = events.request_id where requests.id = {id_here} and events.event_code = 'request-apply-success';
+select count(*) from requests where status='submitted';
+```

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -22,7 +22,8 @@ module "db" {
   # 0 is used to disable enhanced monitoring
   monitoring_interval = 0
   # Remove this to save a final snapshot before database is destroyed
-  skip_final_snapshot = true
+  skip_final_snapshot  = true
+  enable_http_endpoint = true
 
   scaling_configuration = {
     auto_pause               = true

--- a/terraform/rds.tf
+++ b/terraform/rds.tf
@@ -22,7 +22,7 @@ module "db" {
   # 0 is used to disable enhanced monitoring
   monitoring_interval = 0
   # Remove this to save a final snapshot before database is destroyed
-  skip_final_snapshot  = true
+  skip_final_snapshot  = false
   enable_http_endpoint = true
 
   scaling_configuration = {


### PR DESCRIPTION
- turn on data API
- document required sql queries (can be saved to data API once applied in dev/prod)
- turn on save final snapshot (data API updates RDS in place, but safeguard in case something were to go wrong)