### PR TITLE
Chore/resend invite

### DIFF
--- a/app/interfaces/team.ts
+++ b/app/interfaces/team.ts
@@ -9,6 +9,7 @@ export interface User {
   id?: string;
   status?: string;
   pending?: boolean;
+  createdAt?: string;
 }
 
 export interface LoggedInUser {

--- a/app/page-partials/my-requests/TeamInfoTabs.tsx
+++ b/app/page-partials/my-requests/TeamInfoTabs.tsx
@@ -24,7 +24,7 @@ import {
 import { canDeleteMember } from 'utils/helpers';
 import type { Status } from 'interfaces/types';
 
-const INVITATION_EXPIRY_DAYS = 0.01;
+const INVITATION_EXPIRY_DAYS = 2;
 
 const TabWrapper = styled.div`
   padding-left: 1rem;

--- a/app/page-partials/my-requests/TeamInfoTabs.tsx
+++ b/app/page-partials/my-requests/TeamInfoTabs.tsx
@@ -147,9 +147,9 @@ const MemberStatusIcon = ({ pending, invitationSendTime }: { pending?: boolean; 
   if (!invitationSendTime) return null;
   const invitationAgeMilliseconds = new Date().getTime() - new Date(invitationSendTime).getTime();
   const invitationAgeDays = invitationAgeMilliseconds / (60 * 60 * 24 * 1000);
-  let icon = faExclamationCircle;
-  let color = 'black';
-  let title = '';
+  let icon;
+  let color;
+  let title;
   if (pending && invitationAgeDays > INVITATION_EXPIRY_DAYS) {
     icon = faExclamationCircle;
     color = '#ff0303';

--- a/app/pages/verify-user.tsx
+++ b/app/pages/verify-user.tsx
@@ -3,15 +3,56 @@ import ResponsiveContainer, { defaultRules } from 'components/ResponsiveContaine
 import { useRouter } from 'next/router';
 import { LoggedInUser } from 'interfaces/team';
 import { getAuthorizationUrl } from 'utils/openid';
-import getConfig from 'next/config';
 import { Button } from '@bcgov-sso/common-react-components';
-
-const { publicRuntimeConfig = {} } = getConfig() || {};
-const { sso_redirect_uri } = publicRuntimeConfig;
+import ErrorImage from 'svg/ErrorImage';
+import Link from 'next/link';
 
 interface Props {
   currentUser: LoggedInUser;
 }
+
+const content = (
+  <text transform="translate(240 238)" fill="#777" fontSize="16" fontFamily="OpenSans, Open Sans">
+    <tspan x="0" y="0">
+      If you know the team admin, please reach out to them so they
+    </tspan>
+    <tspan x="0" y="26">
+      can re-send the invitation.
+    </tspan>
+
+    <tspan x="0" y="52">
+      You may still
+    </tspan>
+    <tspan y="52" x="120" fill="#006fc4">
+      <Link href="/my-requests">
+        <a>login to your dashboard</a>
+      </Link>
+    </tspan>
+    <tspan y="52"> to start a new integration</tspan>
+    <tspan y="78" x="0">
+      request or view existing integrations.{' '}
+    </tspan>
+    <tspan y="26">.</tspan>
+    <tspan x="120" y="104">
+      If the problem persists for 24 hours,
+    </tspan>
+    <tspan x="120" y="130">
+      contact the team by{' '}
+    </tspan>
+    <tspan y="130" fill="#006fc4">
+      <a href="https://chat.developer.gov.bc.ca/channel/sso" target="_blank" title="Rocket Chat" rel="noreferrer">
+        Rocket.Chat
+      </a>
+    </tspan>
+    <tspan y="130"> or </tspan>
+    <tspan y="130" fill="#006fc4">
+      <a href="mailto:bcgov.sso@gov.bc.ca" title="Pathfinder SSO" target="_blank" rel="noreferrer">
+        Email us
+      </a>
+      .
+    </tspan>
+  </text>
+);
 
 export default function VerifyUser({ currentUser }: Props) {
   const router = useRouter();
@@ -30,12 +71,18 @@ export default function VerifyUser({ currentUser }: Props) {
     <>
       <ResponsiveContainer rules={defaultRules}>
         <h1>{message}</h1>
-        {validated && (
-          <p>You have successfully joined team # {teamId}. Please click below to login and view your dashboard.</p>
+        {validated ? (
+          <>
+            <p>You have successfully joined team # {teamId}. Please click below to login and view your dashboard.</p>
+            <Button onClick={handleLogin} variant="bcPrimary">
+              Login
+            </Button>
+          </>
+        ) : (
+          <ErrorImage message="This link has expired" isError={false}>
+            {content}
+          </ErrorImage>
         )}
-        <Button onClick={handleLogin} variant="bcPrimary">
-          Login
-        </Button>
       </ResponsiveContainer>
     </>
   );

--- a/app/services/team.ts
+++ b/app/services/team.ts
@@ -48,3 +48,12 @@ export const deleteTeamMember = async (userId: number, teamId: number) => {
     return handleAxiosError(err);
   }
 };
+
+export const inviteTeamMember = async (user: User, teamId: number) => {
+  try {
+    const result = await instance.post(`teams/${teamId}/invite`, user).then((res) => res.data);
+    return [result, null];
+  } catch (err) {
+    return handleAxiosError(err);
+  }
+};

--- a/app/svg/ErrorImage.tsx
+++ b/app/svg/ErrorImage.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 interface Props {
   message: string;
   children: React.ReactNode;
+  isError?: boolean;
 }
 
 const SVG = styled.svg.attrs({
@@ -22,7 +23,7 @@ const SVG = styled.svg.attrs({
   }
 `;
 
-const ErrorImage = ({ message, children }: Props) => {
+const ErrorImage = ({ message, children, isError = true }: Props) => {
   return (
     <SVG>
       <defs>
@@ -1136,7 +1137,8 @@ const ErrorImage = ({ message, children }: Props) => {
                 fontWeight="600"
               >
                 <tspan x="0" y="0">
-                  An error has occurred{message ? `: ${message}` : '.'}{' '}
+                  {isError && 'An error has occurred:'}
+                  {message ? ` ${message}` : '.'}{' '}
                 </tspan>
               </text>
               {children}

--- a/lambda/__tests__/03.app.test.ts
+++ b/lambda/__tests__/03.app.test.ts
@@ -107,7 +107,6 @@ describe('requests endpoints', () => {
     const requests = JSON.parse(response.body);
 
     // it should be more than one as one just got created by the previous test
-    console.log(']]]]]]]]]]]]]]]]]]]', requests);
     expect(requests.length).toBeGreaterThan(0);
     expect(response.statusCode).toEqual(200);
 

--- a/lambda/app/src/controllers/team.ts
+++ b/lambda/app/src/controllers/team.ts
@@ -141,7 +141,16 @@ export const userCanReadTeam = async (user: User, teamId: number) => {
   });
 };
 
+const canRemoveUser = async (userId: number, teamId: number) => {
+  const teamMembers = await getUsersOnTeam(teamId);
+  const teamAdmins = teamMembers.filter((member) => member.role === 'admin');
+  if (teamAdmins.length === 1 && teamAdmins.id === userId) return false;
+  return true;
+};
+
 export const removeUserFromTeam = async (userId: number, teamId: number) => {
+  const canRemove = canRemoveUser(userId, teamId);
+  if (!canRemove) throw new Error('Not allowed');
   return models.usersTeam.destroy({
     where: {
       userId,

--- a/lambda/app/src/controllers/team.ts
+++ b/lambda/app/src/controllers/team.ts
@@ -111,6 +111,7 @@ export const getUsersOnTeam = async (teamId: number) => {
         'idirEmail',
         [sequelize.col('usersTeams.role'), 'role'],
         [sequelize.col('usersTeams.pending'), 'pending'],
+        [sequelize.col('usersTeams.created_at'), 'createdAt'],
       ],
     })
     .then((res) => {


### PR DESCRIPTION
- Add icons for member statuses
- Add a resend-invite option on frontend
- Add image markup for invitation errors
- Add backend check and tests that the last admin cant be removed from team
- Add resend-invite backend route
- fix issue with redirection for AWS when verifying team member