### PR TITLE
feat: reference link

### DIFF
--- a/app/layout/Layout.tsx
+++ b/app/layout/Layout.tsx
@@ -145,7 +145,7 @@ const RightMenuItems = () => (
       </a>
     </HoverItem>
     <HoverItem>
-      <a href="https://github.com/bcgov/ocp-sso/wiki" target="_blank" title="Documentation">
+      <a href="https://github.com/bcgov/sso-keycloak/wiki" target="_blank" title="Documentation">
         <FontAwesomeIcon size="2x" icon={faFileAlt} />
       </a>
     </HoverItem>
@@ -188,7 +188,7 @@ function Layout({ children, currentUser, onLoginClick, onLogoutClick }: any) {
           <FontAwesomeIcon size="2x" icon={faEnvelope} />
         </a>
         &nbsp;&nbsp;
-        <a href="https://github.com/bcgov/ocp-sso/wiki" target="_blank" title="Wiki">
+        <a href="https://github.com/bcgov/sso-keycloak/wiki" target="_blank" title="Wiki">
           <FontAwesomeIcon size="2x" icon={faFileAlt} />
         </a>
       </li>

--- a/app/page-partials/faq/FaqItems.tsx
+++ b/app/page-partials/faq/FaqItems.tsx
@@ -29,7 +29,7 @@ export default function FaqItems({ children }: Props) {
               </li>
               <li>
                 To learn more about which identity provider to use, review the{' '}
-                <Link external href="https://github.com/bcgov/ocp-sso/wiki/SSO-Onboarding">
+                <Link external href="https://github.com/bcgov/sso-keycloak/wiki/SSO-Onboarding">
                   SSO Onboarding section
                 </Link>{' '}
                 in our Knowledge base
@@ -61,7 +61,7 @@ export default function FaqItems({ children }: Props) {
               <li>
                 A decision if you want a public of confidential client. To learn more, review the Technical Details
                 under the{' '}
-                <Link external href="https://github.com/bcgov/ocp-sso/wiki/Using-Your-SSO-Client">
+                <Link external href="https://github.com/bcgov/sso-keycloak/wiki/Using-Your-SSO-Client">
                   Using Your SSO Client
                 </Link>{' '}
                 in our SSO Pathfinder Knowledge Base
@@ -111,7 +111,7 @@ export default function FaqItems({ children }: Props) {
             <b>Provider Configuration Endpoint</b> can be used.
           </p>
           <Link
-            href="https://github.com/bcgov/ocp-sso/wiki/Using-Your-SSO-Client#setting-up-your-keycloak-client"
+            href="https://github.com/bcgov/sso-keycloak/wiki/Using-Your-SSO-Client#setting-up-your-keycloak-client"
             external
           >
             Please see the wiki for accessing your provider endpoint information

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -157,7 +157,7 @@ export default function Home({ onLoginClick }: PageProps) {
                     </ul>
                     If you would like to learn more about IM IT Standards,{' '}
                     <Link
-                      href="https://https://github.com/bcgov/sso-keycloak/wiki/Useful-References#imit-identity-standards"
+                      href="https://github.com/bcgov/sso-keycloak/wiki/Useful-References#imit-identity-standards"
                       external
                     >
                       learn more here

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -96,7 +96,7 @@ export default function Home({ onLoginClick }: PageProps) {
                   To learn more about Pathfinder SSO
                   <br />
                   visit the{' '}
-                  <Link size="large" href="https://github.com/bcgov/ocp-sso/wiki" external>
+                  <Link size="large" href="https://github.com/bcgov/sso-keycloak/wiki" external>
                     SSO Pathfinder Knowledge Base
                   </Link>
                 </Paragraph>
@@ -157,7 +157,7 @@ export default function Home({ onLoginClick }: PageProps) {
                     </ul>
                     If you would like to learn more about IM IT Standards,{' '}
                     <Link
-                      href="https://github.com/bcgov/ocp-sso/wiki/Useful-References#imit-identity-standards"
+                      href="https://https://github.com/bcgov/sso-keycloak/wiki/Useful-References#imit-identity-standards"
                       external
                     >
                       learn more here
@@ -180,7 +180,7 @@ export default function Home({ onLoginClick }: PageProps) {
               </Link>
               <br />
               Review our{' '}
-              <Link href="https://github.com/bcgov/ocp-sso/wiki" external>
+              <Link href="https://github.com/bcgov/sso-keycloak/wiki" external>
                 helpful documentation
               </Link>
               <br />


### PR DESCRIPTION
update all WiKi page reference link in CSS home page, from opc-sso/wiki to sso-keycloak/wiki