### PR TITLE
chore: refactor backend routes to mimic expressjs behaviours

### DIFF
--- a/lambda/__tests__/03.app.test.ts
+++ b/lambda/__tests__/03.app.test.ts
@@ -39,17 +39,6 @@ jest.mock('../app/src/github', () => {
 
 const mockedAuthenticate = authenticate as jest.Mock<AuthMock>;
 
-describe('/heartbeat endpoints', () => {
-  it('should response heartbeat endpoint successfully', async () => {
-    const event: APIGatewayProxyEvent = { ...baseEvent, path: '/app/heartbeat' };
-    const context: Context = {};
-
-    const response = await handler(event, context);
-    expect(JSON.parse(response.body).length).toEqual(1);
-    expect(response.statusCode).toEqual(200);
-  });
-});
-
 describe('requests endpoints', () => {
   let requestId;
 

--- a/lambda/__tests__/04.auth.test.ts
+++ b/lambda/__tests__/04.auth.test.ts
@@ -1,0 +1,108 @@
+import { APIGatewayProxyEvent, Context } from 'aws-lambda';
+import { handler } from '../app/src/main';
+import baseEvent from './base-event.json';
+import { authenticate } from '../app/src/authenticate';
+import { TEST_IDIR_USERID, TEST_IDIR_EMAIL, AuthMock } from './00.db.test';
+
+jest.mock('../app/src/authenticate');
+const mockedAuthenticate = authenticate as jest.Mock<AuthMock>;
+
+describe('/non-logged in user endpoints', () => {
+  it('should response heartbeat endpoint successfully', async () => {
+    const event: APIGatewayProxyEvent = { ...baseEvent, path: '/app/heartbeat' };
+    const context: Context = {};
+
+    const response = await handler(event, context);
+    expect(JSON.parse(response.body).length).toEqual(1);
+    expect(response.statusCode).toEqual(200);
+  });
+
+  it('should be redirected without team token to validate', async () => {
+    const event: APIGatewayProxyEvent = { ...baseEvent, path: '/app/teams/verify' };
+    const context: Context = {};
+
+    const response = await handler(event, context);
+
+    expect(response.statusCode).toEqual(301);
+    expect(response.headers.Location).toEqual('/verify-user?message=no-token');
+  });
+
+  it('should have an error with invalid team invitation token', async () => {
+    const event: APIGatewayProxyEvent = {
+      ...baseEvent,
+      path: '/app/teams/verify',
+      queryStringParameters: { token: 'qerasdf' },
+    };
+    const context: Context = {};
+
+    const response = await handler(event, context);
+    expect(response.statusCode).toEqual(422);
+    expect(response.body).toContain('jwt malformed');
+  });
+});
+
+describe('/logged-in endpoints', () => {
+  it('should reject the non-logged user to list integrations', async () => {
+    mockedAuthenticate.mockImplementation(() => {
+      return Promise.resolve(null);
+    });
+
+    const event: APIGatewayProxyEvent = { ...baseEvent, httpMethod: 'POST', path: '/app/requests-all' };
+    const context: Context = {};
+
+    const response = await handler(event, context);
+    expect(response.statusCode).toEqual(401);
+    expect(response.body).toContain('not authorized');
+  });
+
+  it('should allow the logged-in user to list their integrations', async () => {
+    mockedAuthenticate.mockImplementation(() => {
+      return Promise.resolve({
+        idir_userid: TEST_IDIR_USERID,
+        email: TEST_IDIR_EMAIL,
+        client_roles: [],
+        given_name: '',
+        family_name: '',
+      });
+    });
+
+    const event: APIGatewayProxyEvent = { ...baseEvent, httpMethod: 'GET', path: '/app/requests' };
+    const context: Context = {};
+
+    const response = await handler(event, context);
+    expect(response.statusCode).toEqual(200);
+    expect(response.body).toContain('[');
+  });
+
+  it('should reject the non-logged user to create an integration', async () => {
+    mockedAuthenticate.mockImplementation(() => {
+      return Promise.resolve(null);
+    });
+
+    const event: APIGatewayProxyEvent = { ...baseEvent, httpMethod: 'POST', path: '/app/requests' };
+    const context: Context = {};
+
+    const response = await handler(event, context);
+    expect(response.statusCode).toEqual(401);
+    expect(response.body).toContain('not authorized');
+  });
+
+  it('should reject the logged-in user with DB constraint violations when creating an integration', async () => {
+    mockedAuthenticate.mockImplementation(() => {
+      return Promise.resolve({
+        idir_userid: TEST_IDIR_USERID,
+        email: TEST_IDIR_EMAIL,
+        client_roles: [],
+        given_name: '',
+        family_name: '',
+      });
+    });
+
+    const event: APIGatewayProxyEvent = { ...baseEvent, httpMethod: 'POST', path: '/app/requests' };
+    const context: Context = {};
+
+    const response = await handler(event, context);
+    expect(response.statusCode).toEqual(422);
+    expect(response.body).toContain('notNull Violation');
+  });
+});

--- a/lambda/app/src/main.ts
+++ b/lambda/app/src/main.ts
@@ -1,8 +1,79 @@
 import { APIGatewayProxyEvent, Context, Callback } from 'aws-lambda';
+import { isUndefined } from 'lodash';
 const Api = require('lambda-api-router');
 import { setRoutes } from './routes';
 
 const app = new Api();
+
+// since `lambda-api-router` is not 100% compatible with Express.js syntax
+// mock the expected behaviour in the first middleware.
+app._res.redirect = function redirect(url: string) {
+  app._res.headers({ Location: url }).status(301).send();
+};
+
+app._res.set = app._res.headers;
+
+app.use = function use(fn) {
+  this._routes.push({
+    type: 'middleware',
+    fn,
+  });
+};
+
+app._routes.push({
+  type: 'middleware',
+  fn: (req) => {
+    try {
+      req.body = JSON.parse(req.body);
+    } catch {}
+  },
+});
+
+app.listen = async function listen(event, context) {
+  event = {
+    ...event,
+    query: event.queryStringParameters,
+  };
+
+  let matched = false;
+  for (let i = 0; i < this._routes.length; i++) {
+    const { type, route, middleware, fn } = this._routes[i];
+    if (type === 'middleware') {
+      const middRes = await fn(event, this._res);
+      if (middRes === false) {
+        matched = true;
+        break;
+      }
+
+      continue;
+    }
+
+    const match = route.match(event);
+    if (match) {
+      event.params = match.params;
+      matched = true;
+      if (!isUndefined(middleware)) {
+        middleware(event, this._res);
+      }
+      await fn(event, this._res);
+      break;
+    }
+  }
+
+  if (!matched) {
+    return {
+      statusCode: 404,
+      body: '404 The incoming request did not match any known routes.',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    };
+  }
+
+  return this._response;
+};
+// end of mocking behaviours.
 
 setRoutes(app);
 


### PR DESCRIPTION
- mock `lambda-api-router` implementation to mimic its behaviours close to `Express.js`