### PR TITLE
chore: match integration status to the current ones

### DIFF
--- a/app/components/CenteredModal.tsx
+++ b/app/components/CenteredModal.tsx
@@ -129,8 +129,12 @@ const CenteredModal = ({
                 Cancel
               </Button>
             )}
-            <Button onClick={handleConfirm} variant={confirmButtonVariant} type="button">
-              {loading ? <SpinnerGrid color="#FFF" height={18} width={50} visible={loading} /> : confirmText}
+            <Button onClick={handleConfirm} variant={confirmButtonVariant} type="button" className="text-center">
+              {loading ? (
+                <SpinnerGrid color="#FFF" height={18} width={50} wrapperClass="d-block" visible={loading} />
+              ) : (
+                confirmText
+              )}
             </Button>
           </ButtonContainer>
         )}

--- a/app/components/GenericModal.tsx
+++ b/app/components/GenericModal.tsx
@@ -182,9 +182,9 @@ const GenericModal = (
             </Button>
           )}
           {config.showConfirmButton && (
-            <Button onClick={handleConfirm} variant={config.confirmButtonVariant} type="button">
+            <Button onClick={handleConfirm} variant={config.confirmButtonVariant} type="button" className="text-center">
               {loading ? (
-                <SpinnerGrid color="#FFF" height={18} width={50} visible={loading} />
+                <SpinnerGrid color="#FFF" height={18} width={50} wrapperClass="d-block" visible={loading} />
               ) : (
                 config.confirmButtonText
               )}

--- a/app/metadata/options.tsx
+++ b/app/metadata/options.tsx
@@ -4,8 +4,6 @@ export const workflowStatusOptions = [
   { value: 'pr', label: 'PR' },
   { value: 'prFailed', label: 'PR Failed' },
   { value: 'planned', label: 'Planned' },
-  { value: 'planFailed', label: 'Plan Failed' },
-  { value: 'approved', label: 'Approved' },
   { value: 'applied', label: 'Applied' },
   { value: 'applyFailed', label: 'Apply Failed' },
 ];

--- a/app/page-partials/admin-dashboard/MetadataEditModal.tsx
+++ b/app/page-partials/admin-dashboard/MetadataEditModal.tsx
@@ -22,19 +22,17 @@ const StyledDropdown = styled(Dropdown)`
 `;
 
 function MetadataEditModal({ request, onUpdate }: Props) {
-  const [uuid, setUuid] = useState(request.idirUserid);
   const [status, setStatus] = useState(request.status);
 
   const modalId = 'edit-metadata';
 
   const handleMetadataModalConfirm = async () => {
-    await updateRequestMetadata({ id: request.id, idirUserid: uuid, status });
+    await updateRequestMetadata({ id: request.id, status });
     if (onUpdate) await onUpdate();
     window.location.hash = '#';
   };
 
   useEffect(() => {
-    setUuid(request.idirUserid);
     setStatus(request.status);
   }, [request.id]);
 
@@ -42,15 +40,6 @@ function MetadataEditModal({ request, onUpdate }: Props) {
 
   const modalContents = (
     <>
-      <Input
-        label="Owner IDIR UUID"
-        fullWidth={true}
-        onChange={(event: any) => {
-          setUuid(event.target.value);
-        }}
-        value={uuid}
-      />
-      <br />
       <StyledDropdown
         label="Integration Status"
         onChange={(event: any) => {

--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -388,18 +388,14 @@ export const deleteRequest = async (session: Session, user: User, id: number) =>
   }
 };
 
-export const updateRequestMetadata = async (
-  session: Session,
-  user: User,
-  data: { id: number; idirUserid: string; status: string },
-) => {
+export const updateRequestMetadata = async (session: Session, user: User, data: { id: number; status: string }) => {
   if (!session.client_roles?.includes('sso-admin')) {
     throw Error('not allowed');
   }
 
-  const { id, idirUserid, status } = data;
+  const { id, status } = data;
   const result = await models.request.update(
-    { idirUserid, status },
+    { status },
     {
       where: { id },
       returning: true,

--- a/lambda/shared/sequelize/models/Request.ts
+++ b/lambda/shared/sequelize/models/Request.ts
@@ -85,17 +85,7 @@ const init = (sequelize, DataTypes) => {
         defaultValue: false,
       },
       status: {
-        type: DataTypes.ENUM(
-          'draft',
-          'submitted',
-          'pr',
-          'prFailed',
-          'planned',
-          'planFailed',
-          'approved',
-          'applied',
-          'applyFailed',
-        ),
+        type: DataTypes.ENUM('draft', 'submitted', 'pr', 'prFailed', 'planned', 'planFailed', 'applied', 'applyFailed'),
         defaultValue: 'draft',
         allowNull: false,
       },


### PR DESCRIPTION
- match integration status to the current ones.
- remove `idir guid` section from the integration admin modal.
- center the loading `spinner` in the modal.