### PR TITLE
Fixed issue with undefined PR number

### DIFF
--- a/app/page-partials/my-dashboard/TeamInfoTabs.tsx
+++ b/app/page-partials/my-dashboard/TeamInfoTabs.tsx
@@ -415,7 +415,7 @@ function TeamInfoTabs({ alert, currentUser, team, loadTeams }: Props) {
 
   return (
     <>
-      <RequestTabs defaultActiveKey={isAdmin ? 'service-accounts' : 'members'}>
+      <RequestTabs defaultActiveKey={isAdmin && enable_gold ? 'service-accounts' : 'members'}>
         {enable_gold && isAdmin && (
           <Tab eventKey="service-accounts" title="CSS API Account">
             <TabWrapper marginTop="20px">

--- a/lambda/app/src/controllers/team.ts
+++ b/lambda/app/src/controllers/team.ts
@@ -220,7 +220,7 @@ export const getServiceAccount = async (userId: number, teamId: number) => {
       apiServiceAccount: true,
       teamId: { [Op.in]: sequelize.literal(`(${teamIdLiteral})`) },
     },
-    attributes: ['id', 'clientId', 'teamId', 'status', 'updatedAt'],
+    attributes: ['id', 'clientId', 'teamId', 'status', 'updatedAt', 'prNumber'],
     raw: true,
   });
 };


### PR DESCRIPTION
Currently the PR number is undefined and this change shall fix it. Also the `CSS API Account` tab is selected by default if logged in user is an admin and service type is `gold` 