### PR TITLE
chore: using common components 1.28.6

### DIFF
--- a/app/jest/snapshots/__snapshots__/saveMessage.test.tsx.snap
+++ b/app/jest/snapshots/__snapshots__/saveMessage.test.tsx.snap
@@ -3,13 +3,13 @@
 exports[`should match the snapshot 1`] = `
 <DocumentFragment>
   <div
-    class="sc-jIZahH exmPQj"
+    class="sc-jItqcz faRfKQ"
   >
     <span
-      class="sc-ikZpkk eotClJ"
+      class="sc-ilEZps zKhvo"
     >
       <svg
-        class="sc-gicCDI iyyarr"
+        class="sc-gjTGSA jgHhDs"
         data-testid="rotating-lines-svg"
         role="status"
         speed="0.75"
@@ -19,73 +19,73 @@ exports[`should match the snapshot 1`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(0, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(30, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(60, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(90, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(120, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(150, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(180, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(210, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(240, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(270, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(300, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(330, 24, 24)"
           width="5"
@@ -93,7 +93,7 @@ exports[`should match the snapshot 1`] = `
       </svg>
     </span>
     <p
-      class="sc-himrzO dlyeCk"
+      class="sc-hhGHuG hdzKZK"
     >
       saving
     </p>
@@ -104,13 +104,13 @@ exports[`should match the snapshot 1`] = `
 exports[`should match the snapshot 2`] = `
 <DocumentFragment>
   <div
-    class="sc-jIZahH exmPQj"
+    class="sc-jItqcz faRfKQ"
   >
     <span
-      class="sc-ikZpkk eotClJ"
+      class="sc-ilEZps zKhvo"
     >
       <svg
-        class="sc-gicCDI iyyarr"
+        class="sc-gjTGSA jgHhDs"
         data-testid="rotating-lines-svg"
         role="status"
         speed="0.75"
@@ -120,73 +120,73 @@ exports[`should match the snapshot 2`] = `
         xmlns="http://www.w3.org/2000/svg"
       >
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(0, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(30, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(60, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(90, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(120, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(150, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(180, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(210, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(240, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(270, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(300, 24, 24)"
           width="5"
         />
         <polyline
-          class="sc-ezWOiH hHYwTo"
+          class="sc-eACynP itNRyO"
           points="24,12 24,4"
           transform="rotate(330, 24, 24)"
           width="5"
@@ -194,7 +194,7 @@ exports[`should match the snapshot 2`] = `
       </svg>
     </span>
     <p
-      class="sc-himrzO dlyeCk"
+      class="sc-hhGHuG hdzKZK"
     >
       saving
     </p>

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "@bcgov-sso/common-react-components": "1.28.5",
+    "@bcgov-sso/common-react-components": "1.28.6",
     "@bcgov/bc-sans": "1.0.1",
     "@button-inc/bcgov-theme": "1.0.1",
     "@fortawesome/fontawesome-svg-core": "6.2.0",

--- a/app/yarn.lock
+++ b/app/yarn.lock
@@ -1072,10 +1072,10 @@
     "@babel/helper-validator-identifier" "^7.18.6"
     to-fast-properties "^2.0.0"
 
-"@bcgov-sso/common-react-components@1.28.5":
-  version "1.28.5"
-  resolved "https://registry.yarnpkg.com/@bcgov-sso/common-react-components/-/common-react-components-1.28.5.tgz#d6b8ca673665ad7693851854c8fc20e6ddd365c4"
-  integrity sha512-+X7CejC7/NDprA8BhOqfDAyEVmgxQzj7NNU9LslXh8PDILg9P6vmmKlbKh/GytIQvSLRc9gtzgHcpr3uU+h34A==
+"@bcgov-sso/common-react-components@1.28.6":
+  version "1.28.6"
+  resolved "https://registry.yarnpkg.com/@bcgov-sso/common-react-components/-/common-react-components-1.28.6.tgz#029f90e71e10e63665ad343f77b25a03aefe80b2"
+  integrity sha512-truvVz6PlSwENe77YaFhsXMXFIOvrWioHV7eS5b9GjH4QqxOO3WgqNGqLngROivWVQ0NRkA8em5PS7NKlK/7cA==
   dependencies:
     "@button-inc/component-library" "^1.0.1"
     "@fortawesome/fontawesome-svg-core" "^6.1.1"


### PR DESCRIPTION
The vulnerabilities reported by dependabot for the [sso-react-components](https://github.com/bcgov/sso-react-components) have been fixed in the version `1.28.6`. Using this version in our CSS APP