### PR TITLE
fix: form issues with submitting integration updates of team and project lead

### DIFF
--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -172,8 +172,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
     );
 
     const showModal = newData.projectLead === false && newData.usesTeam === false;
-    const togglingTeamToTrue = formData.usesTeam === false && newData.usesTeam === true;
-    const togglingTeamIdToUndefined = newData.usesTeam === false;
+    const togglingTeamToTrue = !formData.usesTeam && newData.usesTeam === true;
     const togglingBceidApprovedToFalse = newData.bceidApproved === true && checkHasNoBceidIdp(newData.devIdps);
 
     if (formData.protocol !== newData.protocol && devIdps.length > 1) {
@@ -190,9 +189,11 @@ function FormTemplate({ currentUser, request, alert }: Props) {
 
     if (newData.authType !== 'browser-login') processed.publicAccess = false;
 
-    if (togglingTeamToTrue) processed.projectLead = undefined;
-    //to prevent the data integrity issue: when choose No-Team, teamId flag retains the old teamId value;
-    if (togglingTeamIdToUndefined) processed.teamId = null;
+    // If user switches to team integration before submitting then set project lead to false
+    if (togglingTeamToTrue) {
+      if (processed.projectLead === true && !isNew) processed.projectLead = false;
+    }
+
     //to prevent the data integrity issue: case for admin role, one can remove bceid-related idps after prod been approved;
     if (togglingBceidApprovedToFalse) processed.bceidApproved = false;
 

--- a/app/schemas-ui/ui-gold.ts
+++ b/app/schemas-ui/ui-gold.ts
@@ -110,7 +110,7 @@ const getUISchema = ({ integration, formData, isAdmin }: Props) => {
     projectLead: {
       'ui:FieldTemplate': FieldRequesterInfo,
       'ui:widget': 'radio',
-      'ui:readonly': !isNew,
+      'ui:readonly': isApplied,
     },
     newToSso: {
       'ui:widget': 'radio',

--- a/app/schemas/requester-info.ts
+++ b/app/schemas/requester-info.ts
@@ -21,7 +21,7 @@ export default function getSchema(teams: any[] = []) {
 
   return {
     type: 'object',
-    customValidation: ['createTeam', 'projectName'],
+    customValidation: ['createTeam', 'projectName', 'projectLead'],
     headerText: 'Enter requester information',
     stepText: 'Requester Info',
     properties: {

--- a/app/utils/validate.ts
+++ b/app/utils/validate.ts
@@ -42,6 +42,7 @@ export const customValidate = (formData: any, errors: FormValidation, fields?: s
     clientId = '',
     devIdps = [],
     protocol = 'oidc',
+    projectLead,
   } = formData;
 
   const fieldMap: any = {
@@ -112,6 +113,12 @@ export const customValidate = (formData: any, errors: FormValidation, fields?: s
     devIdps: () => {
       if (protocol === 'saml' && devIdps.length > 1) {
         errors['devIdps'].addError('Only one identity provider is allowed for saml integrations');
+      }
+    },
+    projectLead: () => {
+      if (usesTeam === false && projectLead === false) {
+        //do not allow to submit a non team integration if user is not a project lead. The error is already shown on the UI
+        errors['projectLead'].addError('');
       }
     },
   };

--- a/lambda/app/src/utils/helpers.ts
+++ b/lambda/app/src/utils/helpers.ts
@@ -50,7 +50,7 @@ const durationAdditionalFields = [];
 });
 
 export const processRequest = (data: any, isMerged: boolean, isAdmin: boolean) => {
-  const immutableFields = ['user', 'userId', 'idirUserid', 'projectLead', 'status', 'serviceType', 'lastChanges'];
+  const immutableFields = ['user', 'userId', 'idirUserid', 'status', 'serviceType', 'lastChanges'];
 
   if (isMerged) {
     immutableFields.push('realm');
@@ -69,6 +69,8 @@ export const processRequest = (data: any, isMerged: boolean, isAdmin: boolean) =
   data.prodRoles = compact(data.prodRoles || []);
 
   if (data.protocol === 'saml') data.authType = 'browser-login';
+
+  if (data.teamId !== null && data.usesTeam === false && data.projectLead === true) data.teamId = null;
 
   return data;
 };


### PR DESCRIPTION
1. Allow users to update project lead if integration is in draft state
2. Remove team id if creating a non team integration before submitting the request
3. Update report to include requester as admin if selecting team integration