### PR TITLE
feat: Survey Frontend

### DIFF
--- a/app/components/SurveyBox.tsx
+++ b/app/components/SurveyBox.tsx
@@ -10,182 +10,200 @@ import { submitSurvey } from '@app/services/user';
 const HEADER_HEIGHT = '4rem';
 
 const SContainer = styled.div`
-    position: fixed;
-    right: 0;
-    bottom: 0;
-    width: 400px;
-    `
+  position: fixed;
+  right: 0;
+  bottom: 0;
+  width: 400px;
+`;
 
 const SBox = styled.div`
-    border-radius: 0.5rem 0.5rem 0 0;
-    background-color: white;
-    transition: height 500ms ease;
-    box-shadow: rgba(0, 0, 0, 0.15) -2px 2px 2.5px;
-    overflow: hidden;
-    position: absolute;
-    width: 100%;
-    bottom: 0;    
+  border-radius: 0.5rem 0.5rem 0 0;
+  background-color: white;
+  transition: height 500ms ease;
+  box-shadow: rgba(0, 0, 0, 0.15) -2px 2px 2.5px;
+  overflow: hidden;
+  position: absolute;
+  width: 100%;
+  bottom: 0;
 
-    &.open {
-        height: 500px;
-    }
+  &.open {
+    height: 500px;
+  }
 
-    &.closed {
-        height: ${HEADER_HEIGHT};
-    }
+  &.closed {
+    height: ${HEADER_HEIGHT};
+  }
 
-    &.hidden {
-        height: 0;
-    }
+  &.hidden {
+    height: 0;
+  }
 
-    .header {
-        background-color: ${SECONDARY_BLUE};
-        display: flex;
-        flex-direction: row;
-        justify-content: space-between;
-        height: ${HEADER_HEIGHT};
-        padding: 1rem;
-        align-items: center;
-        color: white;
-        font-weight: bold;
-        cursor: pointer;
-        font-size: 1.2rem;
-        
-        p {
-            padding: 0;
-            margin: 0;
-        }
-    }
-
-    .body {
-        display: flex;
-        flex-direction: column;
-        padding: 1em;
-        height: calc(100% - ${HEADER_HEIGHT});
-    }
-
-    .button-container {
-        display: flex;
-        justify-content: space-between;
-        width: 100%;
-        margin-top: auto;
-    }
+  .header {
+    background-color: ${SECONDARY_BLUE};
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    height: ${HEADER_HEIGHT};
+    padding: 1rem;
+    align-items: center;
+    color: white;
+    font-weight: bold;
+    cursor: pointer;
+    font-size: 1.2rem;
 
     p {
-        margin: 0;
-
-        &.title {
-            margin-bottom: 0.5rem;
-        }
+      padding: 0;
+      margin: 0;
     }
-`
+  }
+
+  .body {
+    display: flex;
+    flex-direction: column;
+    padding: 1em;
+    height: calc(100% - ${HEADER_HEIGHT});
+  }
+
+  .button-container {
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+    margin-top: auto;
+  }
+
+  p {
+    margin: 0;
+
+    &.title {
+      margin-bottom: 0.5rem;
+    }
+  }
+`;
 
 const SRatingsContainer = styled.div`
+  width: 100%;
+
+  margin: 1.5rem 0 1.5rem 0;
+
+  .stars-box,
+  .stars-text {
     width: 100%;
+    display: flex;
+    justify-content: space-between;
+  }
 
-    margin: 1.5rem 0 1.5rem 0;
-
-    .stars-box, .stars-text {
-        width: 100%;
-        display: flex;
-        justify-content: space-between;
-    }
-
-    .stars-text {
-        padding: 0.5rem 0.1rem 0 0.1rem;
-    }
-`
+  .stars-text {
+    padding: 0.5rem 0.1rem 0 0.1rem;
+  }
+`;
 
 interface Props {
-    setOpenSurvey: (open: boolean) => void;
-    setDisplaySurvey: (open: boolean) => void;
-    open: boolean;
-    display: boolean;
+  setOpenSurvey: (open: boolean) => void;
+  setDisplaySurvey: (open: boolean) => void;
+  open: boolean;
+  display: boolean;
 }
 
 const defaultRatings = [
-    { selected: false, id: 1 },
-    { selected: false, id: 2 },
-    { selected: false, id: 3 },
-    { selected: false, id: 4 },
-    { selected: false, id: 5 },
-]
+  { selected: false, id: 1 },
+  { selected: false, id: 2 },
+  { selected: false, id: 3 },
+  { selected: false, id: 4 },
+  { selected: false, id: 5 },
+];
 
 function SurveyBox({ setOpenSurvey, setDisplaySurvey, open, display }: Props) {
-    const [ratings, setRatings] = useState(defaultRatings);
-    const [surveyMessage, setSurveyMessage] = useState("");
+  const [ratings, setRatings] = useState(defaultRatings);
+  const [surveyMessage, setSurveyMessage] = useState('');
 
-    const handleToggle = () => {
-        setOpenSurvey(!open)
+  const handleToggle = () => {
+    setOpenSurvey(!open);
+  };
+
+  const handleRatingsClick = (clickedIndex: number) => {
+    // Toggle rating back to 0 if clicking the current rating
+    const previousRating = ratings.filter((rating) => rating.selected).length;
+    const selectedRating = clickedIndex + 1;
+    if (previousRating === selectedRating) {
+      setRatings(defaultRatings);
+    } else {
+      setRatings(ratings.map((rating, i) => ({ ...rating, selected: i <= clickedIndex })));
     }
+  };
 
-    const handleRatingsClick = (clickedIndex: number) => {
-        // Toggle rating back to 0 if clicking the current rating
-        const previousRating = ratings.filter(rating => rating.selected).length;
-        const selectedRating = clickedIndex + 1;
-        if (previousRating === selectedRating) {
-            setRatings(defaultRatings)
-        } else {
-            setRatings(ratings.map((rating, i) => ({ ...rating, selected: i <= clickedIndex })))
-        }
+  const hideSurvey = () => setDisplaySurvey(false);
+
+  // Clear internal form state when removed from display
+  useEffect(() => {
+    if (display === false) {
+      setRatings(defaultRatings);
+      setSurveyMessage('');
     }
+  }, [display]);
 
-    const hideSurvey = () => setDisplaySurvey(false);
+  const handleMessageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSurveyMessage(e.target.value);
+  };
 
-    // Clear internal form state when removed from display
-    useEffect(() => {
-        if (display === false) {
-            setRatings(defaultRatings);
-            setSurveyMessage("");
-        }
-    }, [display]);
-    
-    const handleMessageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-        setSurveyMessage(e.target.value)
-    }
-    
-    const saveSurvey = async () => {
-        // Currently just closing survey and not showing user any error message.
-        submitSurvey({
-            message: surveyMessage,
-            rating: ratings.filter(rating => rating.selected).length,
-        });
-        setDisplaySurvey(false);
-        setOpenSurvey(false);
-    }
+  const saveSurvey = async () => {
+    // Currently just closing survey and not showing user any error message.
+    submitSurvey({
+      message: surveyMessage,
+      rating: ratings.filter((rating) => rating.selected).length,
+    });
+    setDisplaySurvey(false);
+    setOpenSurvey(false);
+  };
 
-    const surveyBoxClass = `${open ? 'open' : 'closed'} ${!display && 'hidden'}`
-    return (
-        <SContainer>
-            <SBox className={surveyBoxClass}>
-                <div className="header" onClick={handleToggle}>
-                    <p>We'd love to hear from you</p>
-                    <FontAwesomeIcon icon={faDownLeftAndUpRightToCenter} />
-                </div>
-                <div className='body'>
-                    <p className='title'><strong>Rate our service</strong></p>
-                    <p>How was your experience with the CSS app?</p>
-                    <SRatingsContainer>
-                        <div className='stars-box'>
-                            {ratings.map((rating, i) => (
-                                <FontAwesomeIcon key={rating.id} style={{ cursor: 'pointer' }} role='button' size="3x" icon={faStar} color={rating.selected ? 'gold' : 'grey'} onClick={() => handleRatingsClick(i)} />
-                            ))}
-                        </div>
-                        <div className='stars-text'>
-                            <span>Bad</span>
-                            <span>Great</span>
-                        </div>
-                    </SRatingsContainer>
+  const surveyBoxClass = `${open ? 'open' : 'closed'} ${!display && 'hidden'}`;
+  return (
+    <SContainer>
+      <SBox className={surveyBoxClass}>
+        <div className="header" onClick={handleToggle}>
+          <p>We'd love to hear from you</p>
+          <FontAwesomeIcon icon={faDownLeftAndUpRightToCenter} />
+        </div>
+        <div className="body">
+          <p className="title">
+            <strong>Rate our service</strong>
+          </p>
+          <p>How was your experience with the CSS app?</p>
+          <SRatingsContainer>
+            <div className="stars-box">
+              {ratings.map((rating, i) => (
+                <FontAwesomeIcon
+                  key={rating.id}
+                  style={{ cursor: 'pointer' }}
+                  role="button"
+                  size="3x"
+                  icon={faStar}
+                  color={rating.selected ? 'gold' : 'grey'}
+                  onClick={() => handleRatingsClick(i)}
+                />
+              ))}
+            </div>
+            <div className="stars-text">
+              <span>Bad</span>
+              <span>Great</span>
+            </div>
+          </SRatingsContainer>
 
-                    <Textarea fullWidth placeholder="Leave a message..." rows={4} value={surveyMessage} onChange={handleMessageChange} />
-                    <div className='button-container'>
-                        <Button variant='secondary' onClick={hideSurvey} >Maybe Later</Button>
-                        <Button onClick={saveSurvey}>Rate now</Button>
-                    </div>
-                </div>
-            </SBox>
-        </SContainer>
-    );
+          <Textarea
+            fullWidth
+            placeholder="Leave a message..."
+            rows={4}
+            value={surveyMessage}
+            onChange={handleMessageChange}
+          />
+          <div className="button-container">
+            <Button variant="secondary" onClick={hideSurvey}>
+              Maybe Later
+            </Button>
+            <Button onClick={saveSurvey}>Rate now</Button>
+          </div>
+        </div>
+      </SBox>
+    </SContainer>
+  );
 }
 export default SurveyBox;
-

--- a/app/components/SurveyBox.tsx
+++ b/app/components/SurveyBox.tsx
@@ -112,7 +112,7 @@ const defaultRatings = [
   { selected: false, id: 5 },
 ];
 
-function SurveyBox({ setOpenSurvey, setDisplaySurvey, open, display }: Props) {
+function SurveyBox({ setOpenSurvey, setDisplaySurvey, open, display }: Readonly<Props>) {
   const [ratings, setRatings] = useState(defaultRatings);
   const [surveyMessage, setSurveyMessage] = useState('');
 
@@ -160,7 +160,7 @@ function SurveyBox({ setOpenSurvey, setDisplaySurvey, open, display }: Props) {
     <SContainer>
       <SBox className={surveyBoxClass}>
         <div className="header" onClick={handleToggle}>
-          <p>We'd love to hear from you</p>
+          <p>We&apos;d love to hear from you</p>
           <FontAwesomeIcon icon={faDownLeftAndUpRightToCenter} />
         </div>
         <div className="body">

--- a/app/components/SurveyBox.tsx
+++ b/app/components/SurveyBox.tsx
@@ -1,0 +1,191 @@
+import React, { useState, useEffect } from 'react';
+import styled from 'styled-components';
+import { faDownLeftAndUpRightToCenter, faStar } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { SECONDARY_BLUE } from 'styles/theme';
+import Button from '@button-inc/bcgov-theme/Button';
+import Textarea from '@button-inc/bcgov-theme/Textarea';
+import { submitSurvey } from '@app/services/user';
+
+const HEADER_HEIGHT = '4rem';
+
+const SContainer = styled.div`
+    position: fixed;
+    right: 0;
+    bottom: 0;
+    width: 400px;
+    `
+
+const SBox = styled.div`
+    border-radius: 0.5rem 0.5rem 0 0;
+    background-color: white;
+    transition: height 500ms ease;
+    box-shadow: rgba(0, 0, 0, 0.15) -2px 2px 2.5px;
+    overflow: hidden;
+    position: absolute;
+    width: 100%;
+    bottom: 0;    
+
+    &.open {
+        height: 500px;
+    }
+
+    &.closed {
+        height: ${HEADER_HEIGHT};
+    }
+
+    &.hidden {
+        height: 0;
+    }
+
+    .header {
+        background-color: ${SECONDARY_BLUE};
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        height: ${HEADER_HEIGHT};
+        padding: 1rem;
+        align-items: center;
+        color: white;
+        font-weight: bold;
+        cursor: pointer;
+        font-size: 1.2rem;
+        
+        p {
+            padding: 0;
+            margin: 0;
+        }
+    }
+
+    .body {
+        display: flex;
+        flex-direction: column;
+        padding: 1em;
+        height: calc(100% - ${HEADER_HEIGHT});
+    }
+
+    .button-container {
+        display: flex;
+        justify-content: space-between;
+        width: 100%;
+        margin-top: auto;
+    }
+
+    p {
+        margin: 0;
+
+        &.title {
+            margin-bottom: 0.5rem;
+        }
+    }
+`
+
+const SRatingsContainer = styled.div`
+    width: 100%;
+
+    margin: 1.5rem 0 1.5rem 0;
+
+    .stars-box, .stars-text {
+        width: 100%;
+        display: flex;
+        justify-content: space-between;
+    }
+
+    .stars-text {
+        padding: 0.5rem 0.1rem 0 0.1rem;
+    }
+`
+
+interface Props {
+    setOpenSurvey: (open: boolean) => void;
+    setDisplaySurvey: (open: boolean) => void;
+    open: boolean;
+    display: boolean;
+}
+
+const defaultRatings = [
+    { selected: false, id: 1 },
+    { selected: false, id: 2 },
+    { selected: false, id: 3 },
+    { selected: false, id: 4 },
+    { selected: false, id: 5 },
+]
+
+function SurveyBox({ setOpenSurvey, setDisplaySurvey, open, display }: Props) {
+    const [ratings, setRatings] = useState(defaultRatings);
+    const [surveyMessage, setSurveyMessage] = useState("");
+
+    const handleToggle = () => {
+        setOpenSurvey(!open)
+    }
+
+    const handleRatingsClick = (clickedIndex: number) => {
+        // Toggle rating back to 0 if clicking the current rating
+        const previousRating = ratings.filter(rating => rating.selected).length;
+        const selectedRating = clickedIndex + 1;
+        if (previousRating === selectedRating) {
+            setRatings(defaultRatings)
+        } else {
+            setRatings(ratings.map((rating, i) => ({ ...rating, selected: i <= clickedIndex })))
+        }
+    }
+
+    const hideSurvey = () => setDisplaySurvey(false);
+
+    // Clear internal form state when removed from display
+    useEffect(() => {
+        if (display === false) {
+            setRatings(defaultRatings);
+            setSurveyMessage("");
+        }
+    }, [display]);
+    
+    const handleMessageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        setSurveyMessage(e.target.value)
+    }
+    
+    const saveSurvey = async () => {
+        // Currently just closing survey and not showing user any error message.
+        submitSurvey({
+            message: surveyMessage,
+            rating: ratings.filter(rating => rating.selected).length,
+        });
+        setDisplaySurvey(false);
+        setOpenSurvey(false);
+    }
+
+    const surveyBoxClass = `${open ? 'open' : 'closed'} ${!display && 'hidden'}`
+    return (
+        <SContainer>
+            <SBox className={surveyBoxClass}>
+                <div className="header" onClick={handleToggle}>
+                    <p>We'd love to hear from you</p>
+                    <FontAwesomeIcon icon={faDownLeftAndUpRightToCenter} />
+                </div>
+                <div className='body'>
+                    <p className='title'><strong>Rate our service</strong></p>
+                    <p>How was your experience with the CSS app?</p>
+                    <SRatingsContainer>
+                        <div className='stars-box'>
+                            {ratings.map((rating, i) => (
+                                <FontAwesomeIcon key={rating.id} style={{ cursor: 'pointer' }} role='button' size="3x" icon={faStar} color={rating.selected ? 'gold' : 'grey'} onClick={() => handleRatingsClick(i)} />
+                            ))}
+                        </div>
+                        <div className='stars-text'>
+                            <span>Bad</span>
+                            <span>Great</span>
+                        </div>
+                    </SRatingsContainer>
+
+                    <Textarea fullWidth placeholder="Leave a message..." rows={4} value={surveyMessage} onChange={handleMessageChange} />
+                    <div className='button-container'>
+                        <Button variant='secondary' onClick={hideSurvey} >Maybe Later</Button>
+                        <Button onClick={saveSurvey}>Rate now</Button>
+                    </div>
+                </div>
+            </SBox>
+        </SContainer>
+    );
+}
+export default SurveyBox;
+

--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useContext } from 'react';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import isNil from 'lodash.isnil';
@@ -33,6 +33,7 @@ import { Team, LoggedInUser } from 'interfaces/team';
 import Link from '@button-inc/bcgov-theme/Link';
 import CancelConfirmModal from 'page-partials/edit-request/CancelConfirmModal';
 import { createRequest, updateRequest } from 'services/request';
+import { SurveyContext } from '@app/pages/_app';
 
 const Description = styled.p`
   margin: 0;
@@ -133,6 +134,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
   const [visited, setVisited] = useState<any>(request ? { '0': true } : {});
   const [teams, setTeams] = useState<Team[]>([]);
   const [schemas, setSchemas] = useState<any[]>([]);
+  const surveyContext = useContext(SurveyContext)
   const isNew = isNil(request?.id);
   const isApplied = request?.status === 'applied';
   const isAdmin = currentUser.isAdmin || false;
@@ -331,6 +333,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
           pathname: isAdmin ? '/admin-dashboard' : '/my-dashboard',
           query: { id: formData.id },
         });
+        surveyContext?.setShowSurvey(true, 'createIntegration');
       }
     } catch (err) {
       console.error(err);

--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -134,7 +134,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
   const [visited, setVisited] = useState<any>(request ? { '0': true } : {});
   const [teams, setTeams] = useState<Team[]>([]);
   const [schemas, setSchemas] = useState<any[]>([]);
-  const surveyContext = useContext(SurveyContext)
+  const surveyContext = useContext(SurveyContext);
   const isNew = isNil(request?.id);
   const isApplied = request?.status === 'applied';
   const isAdmin = currentUser.isAdmin || false;

--- a/app/interfaces/Survey.ts
+++ b/app/interfaces/Survey.ts
@@ -1,4 +1,4 @@
 export interface SurveyData {
-    message: string;
-    rating: number;
+  message: string;
+  rating: number;
 }

--- a/app/interfaces/Survey.ts
+++ b/app/interfaces/Survey.ts
@@ -1,0 +1,4 @@
+export interface SurveyData {
+    message: string;
+    rating: number;
+}

--- a/app/interfaces/Survey.ts
+++ b/app/interfaces/Survey.ts
@@ -1,4 +1,7 @@
+import { UserSurveyInformation } from './team';
+
 export interface SurveyData {
   message: string;
   rating: number;
+  triggerEvent: keyof UserSurveyInformation;
 }

--- a/app/interfaces/team.ts
+++ b/app/interfaces/team.ts
@@ -6,11 +6,11 @@ export interface Team {
   serviceAccountCount?: string;
 }
 
-export interface  UserSurveyInformation {  
-    addUserToRole: Boolean,
-    createRole: Boolean,
-    cssApiRequest: Boolean,
-    createIntegration: Boolean,
+export interface UserSurveyInformation {
+  addUserToRole: boolean;
+  createRole: boolean;
+  cssApiRequest: boolean;
+  createIntegration: boolean;
 }
 
 export interface User {

--- a/app/interfaces/team.ts
+++ b/app/interfaces/team.ts
@@ -6,6 +6,13 @@ export interface Team {
   serviceAccountCount?: string;
 }
 
+export interface  UserSurveyInformation {  
+    addUserToRole: Boolean,
+    createRole: Boolean,
+    cssApiRequest: Boolean,
+    createIntegration: Boolean,
+}
+
 export interface User {
   id?: number;
   idirUserid?: string;
@@ -18,6 +25,7 @@ export interface User {
   updatedAt?: string;
   integrations?: any[];
   hasReadGoldNotification?: boolean;
+  surveySubmissions?: UserSurveyInformation;
 }
 
 export interface LoggedInUser {

--- a/app/page-partials/my-dashboard/RoleManagement/index.tsx
+++ b/app/page-partials/my-dashboard/RoleManagement/index.tsx
@@ -22,7 +22,7 @@ const RoleManagement = ({ integration }: Props) => {
   const [environment, setEnvironment] = useState('dev');
   const [canCreateOrDeleteRole, setCanCreateOrDeleteRole] = useState(false);
   const [updateKey, setUpdateKey] = useState(0);
-  const surveyContext = useContext(SurveyContext)
+  const surveyContext = useContext(SurveyContext);
 
   useEffect(() => {
     setEnvironment('dev');
@@ -77,7 +77,7 @@ const RoleManagement = ({ integration }: Props) => {
           } else {
             await contentRef.current.reset();
             setUpdateKey((updateKey) => updateKey + 1);
-            surveyContext?.setShowSurvey(true, 'createRole')
+            surveyContext?.setShowSurvey(true, 'createRole');
           }
         }}
         onCancel={(contentRef: any) => {
@@ -88,7 +88,7 @@ const RoleManagement = ({ integration }: Props) => {
         cancelButtonVariant="secondary"
         style={{ maxHeight: 'calc(100vh - 200px)', overflowY: 'auto' }}
       >
-        <CreateRoleContent integrationId={integration.id as number} environments={environments} />       
+        <CreateRoleContent integrationId={integration.id as number} environments={environments} />
       </GenericModal>
     </>
   );

--- a/app/page-partials/my-dashboard/RoleManagement/index.tsx
+++ b/app/page-partials/my-dashboard/RoleManagement/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useEffect, useState, useRef, useContext } from 'react';
 import styled from 'styled-components';
 import startCase from 'lodash.startcase';
 import { Integration } from 'interfaces/Request';
@@ -7,6 +7,7 @@ import { Button, Tabs, Tab } from '@bcgov-sso/common-react-components';
 import CreateRoleContent from './CreateRoleContent';
 import { canCreateOrDeleteRoles } from '@app/helpers/permissions';
 import RoleEnvironment from './RoleEnvironment';
+import { SurveyContext } from '@app/pages/_app';
 
 const TopMargin = styled.div`
   height: var(--field-top-spacing);
@@ -21,6 +22,7 @@ const RoleManagement = ({ integration }: Props) => {
   const [environment, setEnvironment] = useState('dev');
   const [canCreateOrDeleteRole, setCanCreateOrDeleteRole] = useState(false);
   const [updateKey, setUpdateKey] = useState(0);
+  const surveyContext = useContext(SurveyContext)
 
   useEffect(() => {
     setEnvironment('dev');
@@ -75,6 +77,7 @@ const RoleManagement = ({ integration }: Props) => {
           } else {
             await contentRef.current.reset();
             setUpdateKey((updateKey) => updateKey + 1);
+            surveyContext?.setShowSurvey(true, 'createRole')
           }
         }}
         onCancel={(contentRef: any) => {
@@ -85,7 +88,7 @@ const RoleManagement = ({ integration }: Props) => {
         cancelButtonVariant="secondary"
         style={{ maxHeight: 'calc(100vh - 200px)', overflowY: 'auto' }}
       >
-        <CreateRoleContent integrationId={integration.id as number} environments={environments} />
+        <CreateRoleContent integrationId={integration.id as number} environments={environments} />       
       </GenericModal>
     </>
   );

--- a/app/page-partials/my-dashboard/TeamInfoTabs/index.tsx
+++ b/app/page-partials/my-dashboard/TeamInfoTabs/index.tsx
@@ -224,7 +224,7 @@ function TeamInfoTabs({ alert, currentUser, team, loadTeams }: Props) {
   const [loading, setLoading] = useState(false);
   const [deleteMemberId, setDeleteMemberId] = useState<number>();
   const [modalType, setModalType] = useState('allow');
-  const surveyContext = useContext(SurveyContext)
+  const surveyContext = useContext(SurveyContext);
   const openModal = () => (window.location.hash = addMemberModalId);
 
   const getData = async (teamId: number) => {
@@ -523,30 +523,30 @@ function TeamInfoTabs({ alert, currentUser, team, loadTeams }: Props) {
                 data={
                   integrations?.length > 0
                     ? integrations?.map((integration) => {
-                      return {
-                        status: <RequestStatusIcon status={integration?.status} />,
-                        id: integration.id,
-                        projectName: integration.projectName,
-                        actions: (
-                          <RightFloat>
-                            <ActionButtons
-                              request={integration}
-                              onDelete={() => {
-                                loadTeams();
-                                getData(team?.id);
-                              }}
-                            >
-                              <ActionButton
-                                icon={faEye}
-                                aria-label="view"
-                                onClick={() => viewProject(integration.id)}
-                                size="lg"
-                              />
-                            </ActionButtons>
-                          </RightFloat>
-                        ),
-                      };
-                    })
+                        return {
+                          status: <RequestStatusIcon status={integration?.status} />,
+                          id: integration.id,
+                          projectName: integration.projectName,
+                          actions: (
+                            <RightFloat>
+                              <ActionButtons
+                                request={integration}
+                                onDelete={() => {
+                                  loadTeams();
+                                  getData(team?.id);
+                                }}
+                              >
+                                <ActionButton
+                                  icon={faEye}
+                                  aria-label="view"
+                                  onClick={() => viewProject(integration.id)}
+                                  size="lg"
+                                />
+                              </ActionButtons>
+                            </RightFloat>
+                          ),
+                        };
+                      })
                     : []
                 }
                 readOnly={true}

--- a/app/page-partials/my-dashboard/TeamInfoTabs/index.tsx
+++ b/app/page-partials/my-dashboard/TeamInfoTabs/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { useRouter } from 'next/router';
 import styled from 'styled-components';
 import { Button as RequestButton, Tabs, Tab } from '@bcgov-sso/common-react-components';
@@ -45,6 +45,7 @@ import SubmittedStatusIndicator from 'components/SubmittedStatusIndicator';
 import ServiceAccountsList from './ServiceAccountsList';
 import { InfoMessage } from '@app/components/MessageBox';
 import { Link } from '@button-inc/bcgov-theme';
+import { SurveyContext } from '@app/pages/_app';
 
 const INVITATION_EXPIRY_DAYS = 2;
 
@@ -223,6 +224,7 @@ function TeamInfoTabs({ alert, currentUser, team, loadTeams }: Props) {
   const [loading, setLoading] = useState(false);
   const [deleteMemberId, setDeleteMemberId] = useState<number>();
   const [modalType, setModalType] = useState('allow');
+  const surveyContext = useContext(SurveyContext)
   const openModal = () => (window.location.hash = addMemberModalId);
 
   const getData = async (teamId: number) => {
@@ -521,30 +523,30 @@ function TeamInfoTabs({ alert, currentUser, team, loadTeams }: Props) {
                 data={
                   integrations?.length > 0
                     ? integrations?.map((integration) => {
-                        return {
-                          status: <RequestStatusIcon status={integration?.status} />,
-                          id: integration.id,
-                          projectName: integration.projectName,
-                          actions: (
-                            <RightFloat>
-                              <ActionButtons
-                                request={integration}
-                                onDelete={() => {
-                                  loadTeams();
-                                  getData(team?.id);
-                                }}
-                              >
-                                <ActionButton
-                                  icon={faEye}
-                                  aria-label="view"
-                                  onClick={() => viewProject(integration.id)}
-                                  size="lg"
-                                />
-                              </ActionButtons>
-                            </RightFloat>
-                          ),
-                        };
-                      })
+                      return {
+                        status: <RequestStatusIcon status={integration?.status} />,
+                        id: integration.id,
+                        projectName: integration.projectName,
+                        actions: (
+                          <RightFloat>
+                            <ActionButtons
+                              request={integration}
+                              onDelete={() => {
+                                loadTeams();
+                                getData(team?.id);
+                              }}
+                            >
+                              <ActionButton
+                                icon={faEye}
+                                aria-label="view"
+                                onClick={() => viewProject(integration.id)}
+                                size="lg"
+                              />
+                            </ActionButtons>
+                          </RightFloat>
+                        ),
+                      };
+                    })
                     : []
                 }
                 readOnly={true}
@@ -625,6 +627,7 @@ function TeamInfoTabs({ alert, currentUser, team, loadTeams }: Props) {
                                 content: err,
                               });
                             } else {
+                              surveyContext?.setShowSurvey(true, 'cssApiRequest');
                               fetchTeamServiceAccounts(team.id);
                             }
                           }}

--- a/app/page-partials/my-dashboard/UserRoles.tsx
+++ b/app/page-partials/my-dashboard/UserRoles.tsx
@@ -213,7 +213,7 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
       2000,
       { trailing: true },
     ),
-    [selectedRequest?.id, selectedEnvironment, selectedId],
+    [selectedRequest?.id, selectedEnvironment, selectedId, surveyContext],
   );
 
   const getRoles = async () => {

--- a/app/page-partials/my-dashboard/UserRoles.tsx
+++ b/app/page-partials/my-dashboard/UserRoles.tsx
@@ -192,7 +192,7 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
   const [selectedProperty, setSelectedProperty] = useState<string>('');
   const [searchKey, setSearchKey] = useState<string>('');
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
-  const surveyContext = useContext(SurveyContext)
+  const surveyContext = useContext(SurveyContext);
 
   const throttleUpdate = useCallback(
     throttle(

--- a/app/page-partials/my-dashboard/UserRoles.tsx
+++ b/app/page-partials/my-dashboard/UserRoles.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useRef, useCallback } from 'react';
+import React, { useEffect, useState, useRef, useCallback, useContext } from 'react';
 import styled from 'styled-components';
 import Select, { MultiValue, ActionMeta } from 'react-select';
 import get from 'lodash.get';
@@ -22,6 +22,7 @@ import InfoOverlay from 'components/InfoOverlay';
 import { idpMap } from 'helpers/meta';
 import { KeycloakUser } from 'interfaces/team';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { SurveyContext } from '@app/pages/_app';
 
 const Label = styled.label`
   font-weight: bold;
@@ -191,6 +192,7 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
   const [selectedProperty, setSelectedProperty] = useState<string>('');
   const [searchKey, setSearchKey] = useState<string>('');
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+  const surveyContext = useContext(SurveyContext)
 
   const throttleUpdate = useCallback(
     throttle(
@@ -202,7 +204,10 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
           username: selectedId as string,
           roleNames,
         });
-        if (!err) setSavingMessage(`Last saved at ${new Date().toLocaleString()}`);
+        if (!err) {
+          setSavingMessage(`Last saved at ${new Date().toLocaleString()}`);
+          surveyContext?.setShowSurvey(true, 'addUserToRole');
+        }
         await setSaving(false);
       },
       2000,

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -63,6 +63,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   const [loading, setLoading] = useState(true);
   const [, setError] = useState<any>(null);
   const [refreshTokenState, setRefreshTokenState] = useState('');
+  const [surveyTriggerEvent, setSurveyTriggerEvent] = useState<keyof UserSurveyInformation | null>(null);
   const [displaySurvey, setDisplaySurvey] = useState(false);
   const [openSurvey, setOpenSurvey] = useState(false);
 
@@ -78,11 +79,12 @@ function MyApp({ Component, pageProps }: AppProps) {
     // Update user's profile if this is the first time they're being prompted.
     const userHasTriggered = user.surveySubmissions?.[triggerEvent];
     if (!userHasTriggered) {
-      const [_res, _err] = await updateProfile({
-        surveySubmissions: { ...defaultUserSurveys, ...user.surveySubmissions, [triggerEvent]: true },
-      });
+      const surveySubmissions = { ...defaultUserSurveys, ...user.surveySubmissions, [triggerEvent]: true };
+      const [_res, _err] = await updateProfile({ surveySubmissions });
+      setUser({ ...user, surveySubmissions });
       setDisplaySurvey(show);
       setOpenSurvey(show);
+      setSurveyTriggerEvent(triggerEvent);
     }
   };
 
@@ -260,12 +262,15 @@ function MyApp({ Component, pageProps }: AppProps) {
                 <div>Please login again.</div>{' '}
               </div>
             </GenericModal>
-            <SurveyBox
-              setOpenSurvey={setOpenSurvey}
-              open={openSurvey}
-              display={displaySurvey}
-              setDisplaySurvey={setDisplaySurvey}
-            />
+            {user && (
+              <SurveyBox
+                setOpenSurvey={setOpenSurvey}
+                open={openSurvey}
+                display={displaySurvey}
+                setDisplaySurvey={setDisplaySurvey}
+                triggerEvent={surveyTriggerEvent}
+              />
+            )}
           </>
         )}
       </SurveyContext.Provider>

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import getConfig from 'next/config';
 import type { AppProps } from 'next/app';
@@ -72,19 +72,22 @@ function MyApp({ Component, pageProps }: AppProps) {
     }
   };
 
-  const setShowSurvey = async (show: boolean, triggerEvent: keyof UserSurveyInformation) => {
-    if (!user) return;
+  const setShowSurvey = useCallback(
+    async (show: boolean, triggerEvent: keyof UserSurveyInformation) => {
+      if (!user) return;
 
-    // Update user's profile if this is the first time they're being prompted.
-    const userHasTriggered = user.surveySubmissions?.[triggerEvent];
-    if (!userHasTriggered) {
-      const [_res, err] = await updateProfile({
-        surveySubmissions: { ...defaultUserSurveys, ...user.surveySubmissions, [triggerEvent]: true },
-      });
-      setDisplaySurvey(show);
-      setOpenSurvey(show);
-    }
-  };
+      // Update user's profile if this is the first time they're being prompted.
+      const userHasTriggered = user.surveySubmissions?.[triggerEvent];
+      if (!userHasTriggered) {
+        const [_res, _err] = await updateProfile({
+          surveySubmissions: { ...defaultUserSurveys, ...user.surveySubmissions, [triggerEvent]: true },
+        });
+        setDisplaySurvey(show);
+        setOpenSurvey(show);
+      }
+    },
+    [user],
+  );
 
   useIdleTimer({
     onPrompt,

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -44,11 +44,11 @@ const defaultUserSurveys: UserSurveyInformation = {
   createIntegration: false,
   createRole: false,
   cssApiRequest: false,
-}
+};
 
 export const SessionContext = React.createContext<SessionContextInterface | null>(null);
 export const SurveyContext = React.createContext<{
-  setShowSurvey: (show: boolean, eventType: keyof UserSurveyInformation) => void,
+  setShowSurvey: (show: boolean, eventType: keyof UserSurveyInformation) => void;
 } | null>(null);
 
 const idleTimerTimeout = 300_000; // 5 minutes
@@ -76,13 +76,15 @@ function MyApp({ Component, pageProps }: AppProps) {
     if (!user) return;
 
     // Update user's profile if this is the first time they're being prompted.
-    const userHasTriggered = user.surveySubmissions?.[triggerEvent]
+    const userHasTriggered = user.surveySubmissions?.[triggerEvent];
     if (!userHasTriggered) {
-      const [_res, err] = await updateProfile(({ surveySubmissions: { ...defaultUserSurveys, ...user.surveySubmissions, [triggerEvent]: true } }))
+      const [_res, err] = await updateProfile({
+        surveySubmissions: { ...defaultUserSurveys, ...user.surveySubmissions, [triggerEvent]: true },
+      });
       setDisplaySurvey(show);
       setOpenSurvey(show);
     }
-  }
+  };
 
   useIdleTimer({
     onPrompt,
@@ -205,7 +207,6 @@ function MyApp({ Component, pageProps }: AppProps) {
   return (
     <SessionContext.Provider value={{ session, user }}>
       <SurveyContext.Provider value={{ setShowSurvey }}>
-
         {maintenance_mode && maintenance_mode === 'true' ? (
           <Component {...pageProps} />
         ) : (
@@ -257,7 +258,12 @@ function MyApp({ Component, pageProps }: AppProps) {
                 <div>Please login again.</div>{' '}
               </div>
             </GenericModal>
-            <SurveyBox setOpenSurvey={setOpenSurvey} open={openSurvey} display={displaySurvey} setDisplaySurvey={setDisplaySurvey} />
+            <SurveyBox
+              setOpenSurvey={setOpenSurvey}
+              open={openSurvey}
+              display={displaySurvey}
+              setDisplaySurvey={setDisplaySurvey}
+            />
           </>
         )}
       </SurveyContext.Provider>

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -28,8 +28,11 @@ export const updateProfile = async (data: {
 
 export const submitSurvey = async (surveyData: SurveyData): Promise<[null, null] | [null, AxiosError]> => {
   try {
-    // TODO: Integrate with API route when backend implemented
-    console.info(`Integrate with backend here, survey data is ${JSON.stringify(surveyData, null, 2)}`);
+    await instance.post('surveys', {
+      message: surveyData.message,
+      rating: surveyData.rating,
+      triggerEvent: 'createRole',
+    });
     return [null, null];
   } catch (err: any) {
     return handleAxiosError(err);

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -1,6 +1,7 @@
+import { SurveyData } from '@app/interfaces/Survey';
 import { instance } from './axios';
 import { AxiosError } from 'axios';
-import { Team, User } from 'interfaces/team';
+import { Team, User, UserSurveyInformation } from 'interfaces/team';
 import { handleAxiosError } from 'services/axios';
 
 export const getProfile = async (): Promise<[User, null] | [null, AxiosError]> => {
@@ -15,6 +16,7 @@ export const getProfile = async (): Promise<[User, null] | [null, AxiosError]> =
 export const updateProfile = async (data: {
   additionalEmail?: string;
   hasReadGoldNotification?: boolean;
+  surveySubmissions?: UserSurveyInformation; 
 }): Promise<[User, null] | [null, AxiosError]> => {
   try {
     const result = await instance.post('me', data).then((res) => res.data);
@@ -23,3 +25,14 @@ export const updateProfile = async (data: {
     return handleAxiosError(err);
   }
 };
+
+export const submitSurvey = async (surveyData: SurveyData): Promise<[null, null] | [null, AxiosError]> => {
+  // TODO: Integrate with API route when backend implemented
+  console.info(`Integrate with backend here, survey data is ${JSON.stringify(surveyData, null, 2)}`)
+  try {
+    return [null, null]
+  } catch(err: any) {
+    return handleAxiosError(err)
+  }
+}
+

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -1,7 +1,7 @@
 import { SurveyData } from '@app/interfaces/Survey';
 import { instance } from './axios';
 import { AxiosError } from 'axios';
-import { Team, User, UserSurveyInformation } from 'interfaces/team';
+import { User, UserSurveyInformation } from 'interfaces/team';
 import { handleAxiosError } from 'services/axios';
 
 export const getProfile = async (): Promise<[User, null] | [null, AxiosError]> => {

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -16,7 +16,7 @@ export const getProfile = async (): Promise<[User, null] | [null, AxiosError]> =
 export const updateProfile = async (data: {
   additionalEmail?: string;
   hasReadGoldNotification?: boolean;
-  surveySubmissions?: UserSurveyInformation; 
+  surveySubmissions?: UserSurveyInformation;
 }): Promise<[User, null] | [null, AxiosError]> => {
   try {
     const result = await instance.post('me', data).then((res) => res.data);
@@ -28,11 +28,10 @@ export const updateProfile = async (data: {
 
 export const submitSurvey = async (surveyData: SurveyData): Promise<[null, null] | [null, AxiosError]> => {
   // TODO: Integrate with API route when backend implemented
-  console.info(`Integrate with backend here, survey data is ${JSON.stringify(surveyData, null, 2)}`)
+  console.info(`Integrate with backend here, survey data is ${JSON.stringify(surveyData, null, 2)}`);
   try {
-    return [null, null]
-  } catch(err: any) {
-    return handleAxiosError(err)
+    return [null, null];
+  } catch (err: any) {
+    return handleAxiosError(err);
   }
-}
-
+};

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -30,6 +30,7 @@ export const submitSurvey = async (surveyData: SurveyData): Promise<[null, null]
   // TODO: Integrate with API route when backend implemented
   console.info(`Integrate with backend here, survey data is ${JSON.stringify(surveyData, null, 2)}`);
   try {
+    const result = null;
     return [null, null];
   } catch (err: any) {
     return handleAxiosError(err);

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -27,10 +27,9 @@ export const updateProfile = async (data: {
 };
 
 export const submitSurvey = async (surveyData: SurveyData): Promise<[null, null] | [null, AxiosError]> => {
-  // TODO: Integrate with API route when backend implemented
-  console.info(`Integrate with backend here, survey data is ${JSON.stringify(surveyData, null, 2)}`);
   try {
-    const result = null;
+    // TODO: Integrate with API route when backend implemented
+    console.info(`Integrate with backend here, survey data is ${JSON.stringify(surveyData, null, 2)}`);
     return [null, null];
   } catch (err: any) {
     return handleAxiosError(err);

--- a/lambda/__tests__/12.submit-survey.test.ts
+++ b/lambda/__tests__/12.submit-survey.test.ts
@@ -1,0 +1,61 @@
+import app from './helpers/server';
+import supertest from 'supertest';
+import { APP_BASE_PATH } from './helpers/constants';
+import { cleanUpDatabaseTables, createMockAuth, createMockSendEmail } from './helpers/utils';
+import { SSO_TEAM_IDIR_EMAIL, SSO_TEAM_IDIR_USER } from './helpers/fixtures';
+import { models } from '@lambda-shared/sequelize/models/models';
+
+const surveyData = {
+  rating: 1,
+  message: 'test message',
+  triggerEvent: 'addUserToRole',
+};
+
+jest.mock('../app/src/authenticate');
+jest.mock('../shared/utils/ches', () => {
+  return {
+    sendEmail: jest.fn(),
+  };
+});
+
+describe('Submit Survey', () => {
+  afterAll(async () => {
+    await cleanUpDatabaseTables();
+  });
+
+  it('requires authentication', async () => {
+    const result = await supertest(app)
+      .post(`${APP_BASE_PATH}/surveys`)
+      .send(surveyData)
+      .set('Accept', 'application/json');
+    expect(result.status).toBe(401);
+  });
+
+  it('returns 422 if missing required data', async () => {
+    createMockAuth(SSO_TEAM_IDIR_USER, SSO_TEAM_IDIR_EMAIL);
+    const result = await supertest(app).post(`${APP_BASE_PATH}/surveys`).send({}).set('Accept', 'application/json');
+    expect(result.status).toBe(422);
+  });
+
+  it('Saves survey result and returns 200 if all required data is provided', async () => {
+    createMockAuth(SSO_TEAM_IDIR_USER, SSO_TEAM_IDIR_EMAIL);
+    const result = await supertest(app)
+      .post(`${APP_BASE_PATH}/surveys`)
+      .send(surveyData)
+      .set('Accept', 'application/json');
+    expect(result.status).toBe(200);
+
+    const survey = await models.survey.findOne({ where: { message: 'test message' } });
+    expect(survey).not.toBeNull();
+  });
+
+  it('sends an email to the user and SSO team when a survey is submitted', async () => {
+    const userEmail = 'public.user@mail.com';
+    createMockAuth(SSO_TEAM_IDIR_USER, userEmail);
+    const emailList = createMockSendEmail();
+    await supertest(app).post(`${APP_BASE_PATH}/surveys`).send(surveyData).set('Accept', 'application/json');
+    expect(emailList.length).toBe(2);
+    expect(emailList.find((email) => email.to.includes(userEmail))).toBeDefined();
+    expect(emailList.find((email) => email.to.includes('jonathan.langlois@gov.bc.ca'))).toBeDefined();
+  });
+});

--- a/lambda/__tests__/12.submit-survey.test.ts
+++ b/lambda/__tests__/12.submit-survey.test.ts
@@ -56,6 +56,6 @@ describe('Submit Survey', () => {
     await supertest(app).post(`${APP_BASE_PATH}/surveys`).send(surveyData).set('Accept', 'application/json');
     expect(emailList.length).toBe(2);
     expect(emailList.find((email) => email.to.includes(userEmail))).toBeDefined();
-    expect(emailList.find((email) => email.to.includes('jonathan.langlois@gov.bc.ca'))).toBeDefined();
+    expect(emailList.find((email) => email.to.includes(SSO_TEAM_IDIR_EMAIL))).toBeDefined();
   });
 });

--- a/lambda/__tests__/13.profile.test.ts
+++ b/lambda/__tests__/13.profile.test.ts
@@ -1,0 +1,45 @@
+import { cleanUpDatabaseTables, createMockAuth, createMockSendEmail } from './helpers/utils';
+import { SSO_TEAM_IDIR_EMAIL, SSO_TEAM_IDIR_USER } from './helpers/fixtures';
+import { getAuthenticatedUser, updateProfile } from './helpers/modules/users';
+
+jest.mock('../app/src/authenticate');
+jest.mock('../shared/utils/ches', () => {
+  return {
+    sendEmail: jest.fn(),
+  };
+});
+
+describe('User Profile', () => {
+  beforeEach(() => {
+    createMockAuth(SSO_TEAM_IDIR_USER, SSO_TEAM_IDIR_EMAIL);
+  });
+
+  afterEach(async () => {
+    await cleanUpDatabaseTables();
+  });
+
+  it('includes survey submissions in the profile defaulted to null', async () => {
+    const result = await getAuthenticatedUser();
+    expect(result.status).toBe(200);
+    expect(result.body.surveySubmissions).toBe(null);
+  });
+
+  it('accepts updates to survey submissions when updating the profile', async () => {
+    const newSubmissions = {
+      addUserToRole: true,
+      createRole: true,
+      createIntegration: false,
+      cssApiRequest: false,
+    };
+
+    const updateResult = await updateProfile({
+      role: 'member',
+      idirEmail: SSO_TEAM_IDIR_EMAIL,
+      surveySubmissions: newSubmissions,
+    });
+
+    expect(updateResult.status).toBe(200);
+    const getResult = await getAuthenticatedUser();
+    expect(getResult.body.surveySubmissions).toMatchObject(newSubmissions);
+  });
+});

--- a/lambda/__tests__/13.profile.test.ts
+++ b/lambda/__tests__/13.profile.test.ts
@@ -1,4 +1,4 @@
-import { cleanUpDatabaseTables, createMockAuth, createMockSendEmail } from './helpers/utils';
+import { cleanUpDatabaseTables, createMockAuth } from './helpers/utils';
 import { SSO_TEAM_IDIR_EMAIL, SSO_TEAM_IDIR_USER } from './helpers/fixtures';
 import { getAuthenticatedUser, updateProfile } from './helpers/modules/users';
 

--- a/lambda/__tests__/helpers/modules/users.ts
+++ b/lambda/__tests__/helpers/modules/users.ts
@@ -1,9 +1,14 @@
 import app from '../../helpers/server';
 import supertest from 'supertest';
 import { APP_BASE_PATH } from '../constants';
+import { User } from 'app/interfaces/team';
 
 export const getAuthenticatedUser = async () => {
   return await supertest(app).get(`${APP_BASE_PATH}/me`);
+};
+
+export const updateProfile = async (data: User) => {
+  return await supertest(app).post(`${APP_BASE_PATH}/me`).send(data);
 };
 
 export const deleteInactiveUsers = async (userData: any) => {

--- a/lambda/app/src/controllers/user.ts
+++ b/lambda/app/src/controllers/user.ts
@@ -44,9 +44,9 @@ export const updateProfile = async (
 ) => {
   const { user } = session;
   const myself = await models.user.findOne({ where: { id: user.id } });
-  // TODO: Save survey information in DB here
 
   if (!isNil(data.additionalEmail)) myself.additionalEmail = lowcase(data.additionalEmail);
+  if (!isNil(data.surveySubmissions)) myself.surveySubmissions = data.surveySubmissions;
   if (!isNil(data.hasReadGoldNotification)) myself.hasReadGoldNotification = data.hasReadGoldNotification;
   const updated = await myself.save();
 
@@ -55,6 +55,16 @@ export const updateProfile = async (
   }
 
   return updated.get({ plain: true });
+};
+
+export const createSurvey = (session: Session, data: { message?: string; rating: number; triggerEvent: string }) => {
+  const { message, rating, triggerEvent } = data;
+  return models.survey.create({
+    userId: session.user.id,
+    message,
+    rating,
+    triggerEvent,
+  });
 };
 
 export const listUsersByRole = async (

--- a/lambda/app/src/controllers/user.ts
+++ b/lambda/app/src/controllers/user.ts
@@ -12,6 +12,7 @@ import { disableIntegration } from '@lambda-app/keycloak/client';
 import { EMAILS } from '@lambda-shared/enums';
 import { sendTemplate } from '@lambda-shared/templates';
 import { getAllEmailsOfTeam } from '@lambda-app/queries/team';
+import { UserSurveyInformation } from 'app/interfaces/team';
 
 export const findOrCreateUser = async (session: Session) => {
   let { idir_userid, email } = session;
@@ -39,11 +40,12 @@ export const findOrCreateUser = async (session: Session) => {
 
 export const updateProfile = async (
   session: Session,
-  data: { additionalEmail?: string; hasReadGoldNotification?: boolean },
+  data: { additionalEmail?: string; hasReadGoldNotification?: boolean, surveySubmissions?: UserSurveyInformation },
 ) => {
   const { user } = session;
   const myself = await models.user.findOne({ where: { id: user.id } });
-
+  // TODO: Save survey information in DB here
+  
   if (!isNil(data.additionalEmail)) myself.additionalEmail = lowcase(data.additionalEmail);
   if (!isNil(data.hasReadGoldNotification)) myself.hasReadGoldNotification = data.hasReadGoldNotification;
   const updated = await myself.save();

--- a/lambda/app/src/controllers/user.ts
+++ b/lambda/app/src/controllers/user.ts
@@ -40,12 +40,12 @@ export const findOrCreateUser = async (session: Session) => {
 
 export const updateProfile = async (
   session: Session,
-  data: { additionalEmail?: string; hasReadGoldNotification?: boolean, surveySubmissions?: UserSurveyInformation },
+  data: { additionalEmail?: string; hasReadGoldNotification?: boolean; surveySubmissions?: UserSurveyInformation },
 ) => {
   const { user } = session;
   const myself = await models.user.findOne({ where: { id: user.id } });
   // TODO: Save survey information in DB here
-  
+
   if (!isNil(data.additionalEmail)) myself.additionalEmail = lowcase(data.additionalEmail);
   if (!isNil(data.hasReadGoldNotification)) myself.hasReadGoldNotification = data.hasReadGoldNotification;
   const updated = await myself.save();

--- a/lambda/app/src/controllers/user.ts
+++ b/lambda/app/src/controllers/user.ts
@@ -12,7 +12,7 @@ import { disableIntegration } from '@lambda-app/keycloak/client';
 import { EMAILS } from '@lambda-shared/enums';
 import { sendTemplate } from '@lambda-shared/templates';
 import { getAllEmailsOfTeam } from '@lambda-app/queries/team';
-import { UserSurveyInformation } from 'app/interfaces/team';
+import { UserSurveyInformation } from '@lambda-shared/interfaces';
 
 export const findOrCreateUser = async (session: Session) => {
   let { idir_userid, email } = session;

--- a/lambda/app/src/routes.ts
+++ b/lambda/app/src/routes.ts
@@ -171,7 +171,6 @@ export const setRoutes = (app: any) => {
   app.get(`/me`, async (req, res) => {
     try {
       const integrations = await findMyOrTeamIntegrationsByService(req.user.id);
-      // TODO: Include survey submissions on profile once exists in DB.
       res.status(200).json({ ...req.user, integrations });
     } catch (err) {
       handleError(res, err);

--- a/lambda/app/src/routes.ts
+++ b/lambda/app/src/routes.ts
@@ -168,6 +168,7 @@ export const setRoutes = (app: any) => {
   app.get(`/me`, async (req, res) => {
     try {
       const integrations = await findMyOrTeamIntegrationsByService(req.user.id);
+      // TODO: Include survey submissions on profile once exists in DB.
       res.status(200).json({ ...req.user, integrations });
     } catch (err) {
       handleError(res, err);

--- a/lambda/db/src/migrations/2023.10.11T15.12.25.add-user-surveys.ts
+++ b/lambda/db/src/migrations/2023.10.11T15.12.25.add-user-surveys.ts
@@ -1,0 +1,53 @@
+import { DataTypes } from 'sequelize';
+
+export const name = '2023.10.11T15.12.25.add-user-surveys';
+
+export const up = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().createTable('surveys', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: sequelize.UUIDV4,
+      autoIncrement: true,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      field: 'user_id',
+      allowNull: false,
+      references: { model: 'users', key: 'id' },
+    },
+    triggerEvent: {
+      type: DataTypes.ENUM('createRole', 'addUserToRole', 'cssApiRequest', 'createIntegration'),
+      field: 'trigger_event',
+      allow_null: false,
+    },
+    message: {
+      type: DataTypes.STRING,
+      field: 'message',
+      allowNull: true,
+    },
+    rating: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      field: 'created_at',
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  });
+
+  await sequelize.getQueryInterface().addColumn('users', 'survey_submissions', {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  });
+};
+
+export const down = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().removeColumn('users', 'survey_submissions');
+  await sequelize.getQueryInterface().dropTable('surveys');
+};
+
+export default { name, up, down };

--- a/lambda/db/src/umzug.ts
+++ b/lambda/db/src/umzug.ts
@@ -44,6 +44,7 @@ export const createMigrator = async (logger?: any) => {
       await import('./migrations/2022.09.22T11.00.00.add-additional-role-attribute-in-request-table'),
       await import('./migrations/2022.12.01T13.36.60.add-flag-loginpage-header-title'),
       await import('./migrations/2023.03.17T11.00.00.add-saml-post-logout-uri'),
+      await import('./migrations/2023.10.11T15.12.25.add-user-surveys'),
     ],
     context: sequelize,
     storage: new SequelizeStorage({

--- a/lambda/shared/enums.ts
+++ b/lambda/shared/enums.ts
@@ -33,4 +33,5 @@ export const EMAILS = {
   CREATE_TEAM_API_ACCOUNT_APPROVED: 'create-team-api-account-approved',
   DELETE_TEAM_API_ACCOUNT_SUBMITTED: 'delete-team-api-account-submitted',
   DELETE_INACTIVE_IDIR_USER: 'delete-inactive-idir-users',
+  SURVEY_COMPLETED: 'survey-completed-notification',
 };

--- a/lambda/shared/interfaces.ts
+++ b/lambda/shared/interfaces.ts
@@ -61,3 +61,10 @@ export interface Team {
   name: string;
   members: Member[];
 }
+
+export interface UserSurveyInformation {
+  addUserToRole: boolean;
+  createRole: boolean;
+  cssApiRequest: boolean;
+  createIntegration: boolean;
+}

--- a/lambda/shared/sequelize/models/Survey.ts
+++ b/lambda/shared/sequelize/models/Survey.ts
@@ -1,0 +1,48 @@
+const init = (sequelize, DataTypes) => {
+  const Survey = sequelize.define(
+    'survey',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: sequelize.UUIDV4,
+        autoIncrement: true,
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        field: 'user_id',
+        allow_null: false,
+        references: { model: 'users', key: 'id' },
+      },
+      triggerEvent: {
+        type: DataTypes.ENUM('createRole', 'addUserToRole', 'cssApiRequest', 'createIntegration'),
+        field: 'trigger_event',
+        allow_null: false,
+      },
+      message: {
+        type: DataTypes.STRING,
+        field: 'message',
+        allowNull: true,
+      },
+      rating: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        field: 'created_at',
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      underscored: true,
+      timestamps: false, // Do not need an updated_at field
+    },
+  );
+
+  return Survey;
+};
+
+export default init;

--- a/lambda/shared/sequelize/models/User.ts
+++ b/lambda/shared/sequelize/models/User.ts
@@ -32,6 +32,10 @@ const init = (sequelize, DataTypes) => {
         defaultValue: false,
         field: 'has_read_gold_notification',
       },
+      surveySubmissions: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+      },
     },
     {
       underscored: true,

--- a/lambda/shared/sequelize/models/models.ts
+++ b/lambda/shared/sequelize/models/models.ts
@@ -4,6 +4,7 @@ import Event from './Event';
 import Request from './Request';
 import Team from './Team';
 import User from './User';
+import Survey from './Survey';
 import UserTeam from './UserTeam';
 const env = process.env.NODE_ENV || 'development';
 const config = configs[env];
@@ -22,7 +23,7 @@ if (config.databaseUrl) {
 
 console.log('sequelize initialized', !!sequelize);
 
-[Event, Request, Team, User, UserTeam].forEach((init) => {
+[Event, Request, Team, User, UserTeam, Survey].forEach((init) => {
   const model = init(sequelize, DataTypes);
   models[model.name] = model;
   modelNames.push(model.name);

--- a/lambda/shared/templates/index.ts
+++ b/lambda/shared/templates/index.ts
@@ -18,6 +18,7 @@ import createTeamApiAccountSubmitted from './create-team-api-account-submitted';
 import createTeamApiAccountApproved from './create-team-api-account-approved';
 import deleteTeamApiAccountSubmitted from './delete-team-api-account-submitted';
 import deleteInactiveIdirUsers from './delete-inactive-idir-users';
+import surveyCompleted from './survey-completed-notification';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:3000';
 const API_URL = process.env.API_URL || 'http://localhost:8080/app';
@@ -93,6 +94,9 @@ const getBuilder = (key: string) => {
       break;
     case EMAILS.DELETE_INACTIVE_IDIR_USER:
       builder = deleteInactiveIdirUsers;
+      break;
+    case EMAILS.SURVEY_COMPLETED:
+      builder = surveyCompleted;
       break;
     default:
       break;

--- a/lambda/shared/templates/survey-completed-notification/index.ts
+++ b/lambda/shared/templates/survey-completed-notification/index.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs';
+import Handlebars = require('handlebars');
+import { sendEmail } from '@lambda-shared/utils/ches';
+import { SSO_EMAIL_ADDRESS } from '@lambda-shared/local';
+import { User } from '@lambda-shared/interfaces';
+import { processUser } from '../helpers';
+import { EMAILS } from '@lambda-shared/enums';
+import type { RenderResult } from '../index';
+import { UserSurveyInformation } from 'app/interfaces/team';
+
+const SUBJECT_TEMPLATE = `Survey Completed`;
+const template = fs.readFileSync(__dirname + '/survey-completed-notification.html', 'utf8');
+
+const subjectHandler = Handlebars.compile(SUBJECT_TEMPLATE, { noEscape: true });
+const bodyHandler = Handlebars.compile(template, { noEscape: true });
+
+interface DataProps {
+  user: User;
+  public: boolean;
+  message: string;
+  rating: number;
+  triggerEvent: keyof UserSurveyInformation;
+}
+
+export const render = async (originalData: DataProps): Promise<RenderResult> => {
+  const { user } = originalData;
+  const data = { ...originalData, user: await processUser(user) };
+  return {
+    subject: subjectHandler(data),
+    body: bodyHandler(data),
+  };
+};
+
+export const send = async (data: DataProps, rendered: RenderResult) => {
+  return sendEmail({
+    code: EMAILS.REQUEST_LIMIT_EXCEEDED,
+    to: [data.public ? data.user.idirEmail : SSO_EMAIL_ADDRESS],
+    cc: [],
+    ...rendered,
+  });
+};
+
+export default { render, send };

--- a/lambda/shared/templates/survey-completed-notification/index.ts
+++ b/lambda/shared/templates/survey-completed-notification/index.ts
@@ -6,7 +6,7 @@ import { User } from '@lambda-shared/interfaces';
 import { processUser } from '../helpers';
 import { EMAILS } from '@lambda-shared/enums';
 import type { RenderResult } from '../index';
-import { UserSurveyInformation } from 'app/interfaces/team';
+import { UserSurveyInformation } from '@lambda-shared/interfaces';
 
 const SUBJECT_TEMPLATE = `Survey Completed`;
 const template = fs.readFileSync(__dirname + '/survey-completed-notification.html', 'utf8');

--- a/lambda/shared/templates/survey-completed-notification/index.ts
+++ b/lambda/shared/templates/survey-completed-notification/index.ts
@@ -2,17 +2,16 @@ import * as fs from 'fs';
 import Handlebars = require('handlebars');
 import { sendEmail } from '@lambda-shared/utils/ches';
 import { SSO_EMAIL_ADDRESS } from '@lambda-shared/local';
-import { User } from '@lambda-shared/interfaces';
+import { User, UserSurveyInformation } from '@lambda-shared/interfaces';
 import { processUser } from '../helpers';
 import { EMAILS } from '@lambda-shared/enums';
 import type { RenderResult } from '../index';
-import { UserSurveyInformation } from '@lambda-shared/interfaces';
 
 const SUBJECT_TEMPLATE = `Survey Completed`;
 const template = fs.readFileSync(__dirname + '/survey-completed-notification.html', 'utf8');
 
-const subjectHandler = Handlebars.compile(SUBJECT_TEMPLATE, { noEscape: true });
-const bodyHandler = Handlebars.compile(template, { noEscape: true });
+const subjectHandler = Handlebars.compile(SUBJECT_TEMPLATE);
+const bodyHandler = Handlebars.compile(template);
 
 interface DataProps {
   user: User;

--- a/lambda/shared/templates/survey-completed-notification/survey-completed-notification.html
+++ b/lambda/shared/templates/survey-completed-notification/survey-completed-notification.html
@@ -1,0 +1,8 @@
+<h1>Survey Submitted</h1>
+{{#if public}}
+<p>Thank you for submitting a survey!</p>
+{{else}}
+<p>Pathfinder SSO user <strong>{{user.displayName}} (#{{user.id}})</strong> has submitted a survey.</p>
+<p><strong>Rating:</strong> {{rating}} stars.</p>
+<p><strong>Message:</strong> {{message}}</p>
+{{/if}}

--- a/localserver/express-server.ts
+++ b/localserver/express-server.ts
@@ -5,6 +5,7 @@ import cookieParser from 'cookie-parser';
 import { setRoutes } from '../lambda/app/src/routes';
 import * as actionRoutes from '../lambda/actions/src/routes';
 import * as apiRoutes from '../lambda/css-api/src/routes';
+import cors from 'cors';
 
 const logger = morgan('combined');
 
@@ -22,6 +23,7 @@ const initExpresss = async () => {
   expressServer.use(bodyParser.json());
   expressServer.use(bodyParser.urlencoded({ extended: false }));
   expressServer.use(cookieParser());
+  expressServer.use(cors({origin: 'http://localhost:3000', credentials: true}))
 
   expressServer.disable('x-powered-by');
   expressServer.set('trust proxy', 1);

--- a/localserver/express-server.ts
+++ b/localserver/express-server.ts
@@ -23,7 +23,7 @@ const initExpresss = async () => {
   expressServer.use(bodyParser.json());
   expressServer.use(bodyParser.urlencoded({ extended: false }));
   expressServer.use(cookieParser());
-  expressServer.use(cors({origin: 'http://localhost:3000', credentials: true}))
+  expressServer.use(cors({ origin: 'http://localhost:3000', credentials: true }));
 
   expressServer.disable('x-powered-by');
   expressServer.set('trust proxy', 1);

--- a/localserver/package.json
+++ b/localserver/package.json
@@ -34,5 +34,8 @@
     ],
     "ext": "ts,json",
     "exec": "ts-node -r tsconfig-paths/register -r dotenv/config ./server.ts"
+  },
+  "dependencies": {
+    "cors": "^2.8.5"
   }
 }

--- a/localserver/yarn.lock
+++ b/localserver/yarn.lock
@@ -330,6 +330,14 @@ cookie@0.5.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.5.0.tgz#d1f5d71adec6558c58f389987c366aa47e994f8b"
   integrity sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==
 
+cors@^2.8.5:
+  version "2.8.5"
+  resolved "https://registry.yarnpkg.com/cors/-/cors-2.8.5.tgz#eac11da51592dd86b9f06f6e7ac293b3df875d29"
+  integrity sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==
+  dependencies:
+    object-assign "^4"
+    vary "^1"
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
@@ -689,6 +697,11 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+object-assign@^4:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==
+
 object-inspect@^1.9.0:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
@@ -957,7 +970,7 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
-vary@~1.1.2:
+vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
   integrity sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==


### PR DESCRIPTION
Add in the survey component. The sonarcloud failure is on duplication between the umzug migration file and the sequelize model definition, which are in sync right now since the table is brand new, but should not be logically linked since the model will update over time but the migration is static. Some design decisions:

- I made the survey opening available globally from `_app.tsx`, I think this makes sense since it can be prompted throughout the app and only one survey componenet should ever render at a time
- Added the "has user been prompted" to the profile as a json object, seemed like the appropriate place for it
- Surveys as a new table
- Not notifying frontend users if the survey fails to send, these will be in our API logs and figure it would just annoy users to get an error message on an optional survey
- Some changes to localserver, I was hitting cors errors running locally so added the cors package to allow localhost as origin and credentials