### PR TITLE
feat: CSS Survey Backend

### DIFF
--- a/app/interfaces/Survey.ts
+++ b/app/interfaces/Survey.ts
@@ -1,4 +1,7 @@
+import { UserSurveyInformation } from './team';
+
 export interface SurveyData {
   message: string;
   rating: number;
+  triggerEvent: keyof UserSurveyInformation;
 }

--- a/app/page-partials/my-dashboard/UserRoles.tsx
+++ b/app/page-partials/my-dashboard/UserRoles.tsx
@@ -213,7 +213,7 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
       2000,
       { trailing: true },
     ),
-    [selectedRequest?.id, selectedEnvironment, selectedId],
+    [selectedRequest?.id, selectedEnvironment, selectedId, surveyContext],
   );
 
   const getRoles = async () => {

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -63,6 +63,7 @@ function MyApp({ Component, pageProps }: AppProps) {
   const [loading, setLoading] = useState(true);
   const [, setError] = useState<any>(null);
   const [refreshTokenState, setRefreshTokenState] = useState('');
+  const [surveyTriggerEvent, setSurveyTriggerEvent] = useState<keyof UserSurveyInformation | null>(null);
   const [displaySurvey, setDisplaySurvey] = useState(false);
   const [openSurvey, setOpenSurvey] = useState(false);
 
@@ -78,11 +79,12 @@ function MyApp({ Component, pageProps }: AppProps) {
     // Update user's profile if this is the first time they're being prompted.
     const userHasTriggered = user.surveySubmissions?.[triggerEvent];
     if (!userHasTriggered) {
-      const [_res, _err] = await updateProfile({
-        surveySubmissions: { ...defaultUserSurveys, ...user.surveySubmissions, [triggerEvent]: true },
-      });
+      const surveySubmissions = { ...defaultUserSurveys, ...user.surveySubmissions, [triggerEvent]: true };
+      const [_res, _err] = await updateProfile({ surveySubmissions });
+      setUser({ ...user, surveySubmissions });
       setDisplaySurvey(show);
       setOpenSurvey(show);
+      setSurveyTriggerEvent(triggerEvent);
     }
   };
 
@@ -260,12 +262,15 @@ function MyApp({ Component, pageProps }: AppProps) {
                 <div>Please login again.</div>{' '}
               </div>
             </GenericModal>
-            <SurveyBox
-              setOpenSurvey={setOpenSurvey}
-              open={openSurvey}
-              display={displaySurvey}
-              setDisplaySurvey={setDisplaySurvey}
-            />
+            {user && (
+              <SurveyBox
+                setOpenSurvey={setOpenSurvey}
+                open={openSurvey}
+                display={displaySurvey}
+                setDisplaySurvey={setDisplaySurvey}
+                triggerEvent={surveyTriggerEvent}
+              />
+            )}
           </>
         )}
       </SurveyContext.Provider>

--- a/app/services/user.ts
+++ b/app/services/user.ts
@@ -28,8 +28,11 @@ export const updateProfile = async (data: {
 
 export const submitSurvey = async (surveyData: SurveyData): Promise<[null, null] | [null, AxiosError]> => {
   try {
-    // TODO: Integrate with API route when backend implemented
-    console.info(`Integrate with backend here, survey data is ${JSON.stringify(surveyData, null, 2)}`);
+    await instance.post('surveys', {
+      message: surveyData.message,
+      rating: surveyData.rating,
+      triggerEvent: 'createRole',
+    });
     return [null, null];
   } catch (err: any) {
     return handleAxiosError(err);

--- a/lambda/__tests__/12.submit-survey.test.ts
+++ b/lambda/__tests__/12.submit-survey.test.ts
@@ -1,0 +1,61 @@
+import app from './helpers/server';
+import supertest from 'supertest';
+import { APP_BASE_PATH } from './helpers/constants';
+import { cleanUpDatabaseTables, createMockAuth, createMockSendEmail } from './helpers/utils';
+import { SSO_TEAM_IDIR_EMAIL, SSO_TEAM_IDIR_USER } from './helpers/fixtures';
+import { models } from '@lambda-shared/sequelize/models/models';
+
+const surveyData = {
+  rating: 1,
+  message: 'test message',
+  triggerEvent: 'addUserToRole',
+};
+
+jest.mock('../app/src/authenticate');
+jest.mock('../shared/utils/ches', () => {
+  return {
+    sendEmail: jest.fn(),
+  };
+});
+
+describe('Submit Survey', () => {
+  afterAll(async () => {
+    await cleanUpDatabaseTables();
+  });
+
+  it('requires authentication', async () => {
+    const result = await supertest(app)
+      .post(`${APP_BASE_PATH}/surveys`)
+      .send(surveyData)
+      .set('Accept', 'application/json');
+    expect(result.status).toBe(401);
+  });
+
+  it('returns 422 if missing required data', async () => {
+    createMockAuth(SSO_TEAM_IDIR_USER, SSO_TEAM_IDIR_EMAIL);
+    const result = await supertest(app).post(`${APP_BASE_PATH}/surveys`).send({}).set('Accept', 'application/json');
+    expect(result.status).toBe(422);
+  });
+
+  it('Saves survey result and returns 200 if all required data is provided', async () => {
+    createMockAuth(SSO_TEAM_IDIR_USER, SSO_TEAM_IDIR_EMAIL);
+    const result = await supertest(app)
+      .post(`${APP_BASE_PATH}/surveys`)
+      .send(surveyData)
+      .set('Accept', 'application/json');
+    expect(result.status).toBe(200);
+
+    const survey = await models.survey.findOne({ where: { message: 'test message' } });
+    expect(survey).not.toBeNull();
+  });
+
+  it('sends an email to the user and SSO team when a survey is submitted', async () => {
+    const userEmail = 'public.user@mail.com';
+    createMockAuth(SSO_TEAM_IDIR_USER, userEmail);
+    const emailList = createMockSendEmail();
+    await supertest(app).post(`${APP_BASE_PATH}/surveys`).send(surveyData).set('Accept', 'application/json');
+    expect(emailList.length).toBe(2);
+    expect(emailList.find((email) => email.to.includes(userEmail))).toBeDefined();
+    expect(emailList.find((email) => email.to.includes('jonathan.langlois@gov.bc.ca'))).toBeDefined();
+  });
+});

--- a/lambda/__tests__/12.submit-survey.test.ts
+++ b/lambda/__tests__/12.submit-survey.test.ts
@@ -56,6 +56,6 @@ describe('Submit Survey', () => {
     await supertest(app).post(`${APP_BASE_PATH}/surveys`).send(surveyData).set('Accept', 'application/json');
     expect(emailList.length).toBe(2);
     expect(emailList.find((email) => email.to.includes(userEmail))).toBeDefined();
-    expect(emailList.find((email) => email.to.includes('jonathan.langlois@gov.bc.ca'))).toBeDefined();
+    expect(emailList.find((email) => email.to.includes(SSO_TEAM_IDIR_EMAIL))).toBeDefined();
   });
 });

--- a/lambda/__tests__/13.profile.test.ts
+++ b/lambda/__tests__/13.profile.test.ts
@@ -1,0 +1,45 @@
+import { cleanUpDatabaseTables, createMockAuth, createMockSendEmail } from './helpers/utils';
+import { SSO_TEAM_IDIR_EMAIL, SSO_TEAM_IDIR_USER } from './helpers/fixtures';
+import { getAuthenticatedUser, updateProfile } from './helpers/modules/users';
+
+jest.mock('../app/src/authenticate');
+jest.mock('../shared/utils/ches', () => {
+  return {
+    sendEmail: jest.fn(),
+  };
+});
+
+describe('User Profile', () => {
+  beforeEach(() => {
+    createMockAuth(SSO_TEAM_IDIR_USER, SSO_TEAM_IDIR_EMAIL);
+  });
+
+  afterEach(async () => {
+    await cleanUpDatabaseTables();
+  });
+
+  it('includes survey submissions in the profile defaulted to null', async () => {
+    const result = await getAuthenticatedUser();
+    expect(result.status).toBe(200);
+    expect(result.body.surveySubmissions).toBe(null);
+  });
+
+  it('accepts updates to survey submissions when updating the profile', async () => {
+    const newSubmissions = {
+      addUserToRole: true,
+      createRole: true,
+      createIntegration: false,
+      cssApiRequest: false,
+    };
+
+    const updateResult = await updateProfile({
+      role: 'member',
+      idirEmail: SSO_TEAM_IDIR_EMAIL,
+      surveySubmissions: newSubmissions,
+    });
+
+    expect(updateResult.status).toBe(200);
+    const getResult = await getAuthenticatedUser();
+    expect(getResult.body.surveySubmissions).toMatchObject(newSubmissions);
+  });
+});

--- a/lambda/__tests__/13.profile.test.ts
+++ b/lambda/__tests__/13.profile.test.ts
@@ -1,4 +1,4 @@
-import { cleanUpDatabaseTables, createMockAuth, createMockSendEmail } from './helpers/utils';
+import { cleanUpDatabaseTables, createMockAuth } from './helpers/utils';
 import { SSO_TEAM_IDIR_EMAIL, SSO_TEAM_IDIR_USER } from './helpers/fixtures';
 import { getAuthenticatedUser, updateProfile } from './helpers/modules/users';
 

--- a/lambda/__tests__/helpers/modules/users.ts
+++ b/lambda/__tests__/helpers/modules/users.ts
@@ -1,9 +1,14 @@
 import app from '../../helpers/server';
 import supertest from 'supertest';
 import { APP_BASE_PATH } from '../constants';
+import { User } from 'app/interfaces/team';
 
 export const getAuthenticatedUser = async () => {
   return await supertest(app).get(`${APP_BASE_PATH}/me`);
+};
+
+export const updateProfile = async (data: User) => {
+  return await supertest(app).post(`${APP_BASE_PATH}/me`).send(data);
 };
 
 export const deleteInactiveUsers = async (userData: any) => {

--- a/lambda/app/src/controllers/user.ts
+++ b/lambda/app/src/controllers/user.ts
@@ -44,9 +44,9 @@ export const updateProfile = async (
 ) => {
   const { user } = session;
   const myself = await models.user.findOne({ where: { id: user.id } });
-  // TODO: Save survey information in DB here
 
   if (!isNil(data.additionalEmail)) myself.additionalEmail = lowcase(data.additionalEmail);
+  if (!isNil(data.surveySubmissions)) myself.surveySubmissions = data.surveySubmissions;
   if (!isNil(data.hasReadGoldNotification)) myself.hasReadGoldNotification = data.hasReadGoldNotification;
   const updated = await myself.save();
 
@@ -55,6 +55,16 @@ export const updateProfile = async (
   }
 
   return updated.get({ plain: true });
+};
+
+export const createSurvey = (session: Session, data: { message?: string; rating: number; triggerEvent: string }) => {
+  const { message, rating, triggerEvent } = data;
+  return models.survey.create({
+    userId: session.user.id,
+    message,
+    rating,
+    triggerEvent,
+  });
 };
 
 export const listUsersByRole = async (

--- a/lambda/app/src/controllers/user.ts
+++ b/lambda/app/src/controllers/user.ts
@@ -12,7 +12,7 @@ import { disableIntegration } from '@lambda-app/keycloak/client';
 import { EMAILS } from '@lambda-shared/enums';
 import { sendTemplate } from '@lambda-shared/templates';
 import { getAllEmailsOfTeam } from '@lambda-app/queries/team';
-import { UserSurveyInformation } from 'app/interfaces/team';
+import { UserSurveyInformation } from '@lambda-shared/interfaces';
 
 export const findOrCreateUser = async (session: Session) => {
   let { idir_userid, email } = session;

--- a/lambda/db/src/migrations/2023.10.11T15.12.25.add-user-surveys.ts
+++ b/lambda/db/src/migrations/2023.10.11T15.12.25.add-user-surveys.ts
@@ -1,0 +1,53 @@
+import { DataTypes } from 'sequelize';
+
+export const name = '2023.10.11T15.12.25.add-user-surveys';
+
+export const up = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().createTable('surveys', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: sequelize.UUIDV4,
+      autoIncrement: true,
+    },
+    userId: {
+      type: DataTypes.INTEGER,
+      field: 'user_id',
+      allowNull: false,
+      references: { model: 'users', key: 'id' },
+    },
+    triggerEvent: {
+      type: DataTypes.ENUM('createRole', 'addUserToRole', 'cssApiRequest', 'createIntegration'),
+      field: 'trigger_event',
+      allow_null: false,
+    },
+    message: {
+      type: DataTypes.STRING,
+      field: 'message',
+      allowNull: true,
+    },
+    rating: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      field: 'created_at',
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+  });
+
+  await sequelize.getQueryInterface().addColumn('users', 'survey_submissions', {
+    type: DataTypes.JSONB,
+    allowNull: true,
+  });
+};
+
+export const down = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().removeColumn('users', 'survey_submissions');
+  await sequelize.getQueryInterface().dropTable('surveys');
+};
+
+export default { name, up, down };

--- a/lambda/db/src/umzug.ts
+++ b/lambda/db/src/umzug.ts
@@ -44,6 +44,7 @@ export const createMigrator = async (logger?: any) => {
       await import('./migrations/2022.09.22T11.00.00.add-additional-role-attribute-in-request-table'),
       await import('./migrations/2022.12.01T13.36.60.add-flag-loginpage-header-title'),
       await import('./migrations/2023.03.17T11.00.00.add-saml-post-logout-uri'),
+      await import('./migrations/2023.10.11T15.12.25.add-user-surveys'),
     ],
     context: sequelize,
     storage: new SequelizeStorage({

--- a/lambda/shared/enums.ts
+++ b/lambda/shared/enums.ts
@@ -33,4 +33,5 @@ export const EMAILS = {
   CREATE_TEAM_API_ACCOUNT_APPROVED: 'create-team-api-account-approved',
   DELETE_TEAM_API_ACCOUNT_SUBMITTED: 'delete-team-api-account-submitted',
   DELETE_INACTIVE_IDIR_USER: 'delete-inactive-idir-users',
+  SURVEY_COMPLETED: 'survey-completed-notification',
 };

--- a/lambda/shared/interfaces.ts
+++ b/lambda/shared/interfaces.ts
@@ -61,3 +61,10 @@ export interface Team {
   name: string;
   members: Member[];
 }
+
+export interface UserSurveyInformation {
+  addUserToRole: boolean;
+  createRole: boolean;
+  cssApiRequest: boolean;
+  createIntegration: boolean;
+}

--- a/lambda/shared/sequelize/models/Survey.ts
+++ b/lambda/shared/sequelize/models/Survey.ts
@@ -1,0 +1,48 @@
+const init = (sequelize, DataTypes) => {
+  const Survey = sequelize.define(
+    'survey',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        defaultValue: sequelize.UUIDV4,
+        autoIncrement: true,
+      },
+      userId: {
+        type: DataTypes.INTEGER,
+        field: 'user_id',
+        allow_null: false,
+        references: { model: 'users', key: 'id' },
+      },
+      triggerEvent: {
+        type: DataTypes.ENUM('createRole', 'addUserToRole', 'cssApiRequest', 'createIntegration'),
+        field: 'trigger_event',
+        allow_null: false,
+      },
+      message: {
+        type: DataTypes.STRING,
+        field: 'message',
+        allowNull: true,
+      },
+      rating: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      createdAt: {
+        type: DataTypes.DATE,
+        field: 'created_at',
+        allowNull: false,
+        defaultValue: DataTypes.NOW,
+      },
+    },
+    {
+      underscored: true,
+      timestamps: false, // Do not need an updated_at field
+    },
+  );
+
+  return Survey;
+};
+
+export default init;

--- a/lambda/shared/sequelize/models/User.ts
+++ b/lambda/shared/sequelize/models/User.ts
@@ -32,6 +32,10 @@ const init = (sequelize, DataTypes) => {
         defaultValue: false,
         field: 'has_read_gold_notification',
       },
+      surveySubmissions: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+      },
     },
     {
       underscored: true,

--- a/lambda/shared/sequelize/models/models.ts
+++ b/lambda/shared/sequelize/models/models.ts
@@ -4,6 +4,7 @@ import Event from './Event';
 import Request from './Request';
 import Team from './Team';
 import User from './User';
+import Survey from './Survey';
 import UserTeam from './UserTeam';
 const env = process.env.NODE_ENV || 'development';
 const config = configs[env];
@@ -22,7 +23,7 @@ if (config.databaseUrl) {
 
 console.log('sequelize initialized', !!sequelize);
 
-[Event, Request, Team, User, UserTeam].forEach((init) => {
+[Event, Request, Team, User, UserTeam, Survey].forEach((init) => {
   const model = init(sequelize, DataTypes);
   models[model.name] = model;
   modelNames.push(model.name);

--- a/lambda/shared/templates/index.ts
+++ b/lambda/shared/templates/index.ts
@@ -18,6 +18,7 @@ import createTeamApiAccountSubmitted from './create-team-api-account-submitted';
 import createTeamApiAccountApproved from './create-team-api-account-approved';
 import deleteTeamApiAccountSubmitted from './delete-team-api-account-submitted';
 import deleteInactiveIdirUsers from './delete-inactive-idir-users';
+import surveyCompleted from './survey-completed-notification';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:3000';
 const API_URL = process.env.API_URL || 'http://localhost:8080/app';
@@ -93,6 +94,9 @@ const getBuilder = (key: string) => {
       break;
     case EMAILS.DELETE_INACTIVE_IDIR_USER:
       builder = deleteInactiveIdirUsers;
+      break;
+    case EMAILS.SURVEY_COMPLETED:
+      builder = surveyCompleted;
       break;
     default:
       break;

--- a/lambda/shared/templates/survey-completed-notification/index.ts
+++ b/lambda/shared/templates/survey-completed-notification/index.ts
@@ -1,0 +1,43 @@
+import * as fs from 'fs';
+import Handlebars = require('handlebars');
+import { sendEmail } from '@lambda-shared/utils/ches';
+import { SSO_EMAIL_ADDRESS } from '@lambda-shared/local';
+import { User } from '@lambda-shared/interfaces';
+import { processUser } from '../helpers';
+import { EMAILS } from '@lambda-shared/enums';
+import type { RenderResult } from '../index';
+import { UserSurveyInformation } from 'app/interfaces/team';
+
+const SUBJECT_TEMPLATE = `Survey Completed`;
+const template = fs.readFileSync(__dirname + '/survey-completed-notification.html', 'utf8');
+
+const subjectHandler = Handlebars.compile(SUBJECT_TEMPLATE, { noEscape: true });
+const bodyHandler = Handlebars.compile(template, { noEscape: true });
+
+interface DataProps {
+  user: User;
+  public: boolean;
+  message: string;
+  rating: number;
+  triggerEvent: keyof UserSurveyInformation;
+}
+
+export const render = async (originalData: DataProps): Promise<RenderResult> => {
+  const { user } = originalData;
+  const data = { ...originalData, user: await processUser(user) };
+  return {
+    subject: subjectHandler(data),
+    body: bodyHandler(data),
+  };
+};
+
+export const send = async (data: DataProps, rendered: RenderResult) => {
+  return sendEmail({
+    code: EMAILS.REQUEST_LIMIT_EXCEEDED,
+    to: [data.public ? data.user.idirEmail : SSO_EMAIL_ADDRESS],
+    cc: [],
+    ...rendered,
+  });
+};
+
+export default { render, send };

--- a/lambda/shared/templates/survey-completed-notification/index.ts
+++ b/lambda/shared/templates/survey-completed-notification/index.ts
@@ -6,7 +6,7 @@ import { User } from '@lambda-shared/interfaces';
 import { processUser } from '../helpers';
 import { EMAILS } from '@lambda-shared/enums';
 import type { RenderResult } from '../index';
-import { UserSurveyInformation } from 'app/interfaces/team';
+import { UserSurveyInformation } from '@lambda-shared/interfaces';
 
 const SUBJECT_TEMPLATE = `Survey Completed`;
 const template = fs.readFileSync(__dirname + '/survey-completed-notification.html', 'utf8');

--- a/lambda/shared/templates/survey-completed-notification/index.ts
+++ b/lambda/shared/templates/survey-completed-notification/index.ts
@@ -2,17 +2,16 @@ import * as fs from 'fs';
 import Handlebars = require('handlebars');
 import { sendEmail } from '@lambda-shared/utils/ches';
 import { SSO_EMAIL_ADDRESS } from '@lambda-shared/local';
-import { User } from '@lambda-shared/interfaces';
+import { User, UserSurveyInformation } from '@lambda-shared/interfaces';
 import { processUser } from '../helpers';
 import { EMAILS } from '@lambda-shared/enums';
 import type { RenderResult } from '../index';
-import { UserSurveyInformation } from '@lambda-shared/interfaces';
 
 const SUBJECT_TEMPLATE = `Survey Completed`;
 const template = fs.readFileSync(__dirname + '/survey-completed-notification.html', 'utf8');
 
-const subjectHandler = Handlebars.compile(SUBJECT_TEMPLATE, { noEscape: true });
-const bodyHandler = Handlebars.compile(template, { noEscape: true });
+const subjectHandler = Handlebars.compile(SUBJECT_TEMPLATE);
+const bodyHandler = Handlebars.compile(template);
 
 interface DataProps {
   user: User;

--- a/lambda/shared/templates/survey-completed-notification/survey-completed-notification.html
+++ b/lambda/shared/templates/survey-completed-notification/survey-completed-notification.html
@@ -1,0 +1,8 @@
+<h1>Survey Submitted</h1>
+{{#if public}}
+<p>Thank you for submitting a survey!</p>
+{{else}}
+<p>Pathfinder SSO user <strong>{{user.displayName}} (#{{user.id}})</strong> has submitted a survey.</p>
+<p><strong>Rating:</strong> {{rating}} stars.</p>
+<p><strong>Message:</strong> {{message}}</p>
+{{/if}}


### PR DESCRIPTION
Mostly the backend contents for the survey piece, I added some small frontend updates as well:

- Not allowing 0 star rating anymore
- Limit of 254 characters for messages
- Small fix in a dependency array that was missing
- Saving the triggering event

Just a note for the frontend error handling, I left it just closing the survey regardless of survey submission status. I figure it would be really annoying to get re-prompted to submit an optional form because of an app failure. But followed the same pattern as other services so can easily add some prompt if desired.

For the backend, it adds a "surveys" table and tracks survey submissions on the users profile. I kept the survey tracking just as a denormalized json blob on the profile, makes sense to me since I think these events are likely to change over time to be a bit loose with it. It also emails the user and our team when a survey is submitted.

