### PR TITLE
fix: survey

### DIFF
--- a/app/components/SurveyBox.tsx
+++ b/app/components/SurveyBox.tsx
@@ -32,7 +32,6 @@ const SBox = styled.div`
   position: absolute;
   width: 100%;
   bottom: 0;
-  z-index: 10000;
 
   &.open {
     height: 500px;

--- a/app/components/SurveyBox.tsx
+++ b/app/components/SurveyBox.tsx
@@ -20,6 +20,7 @@ const SContainer = styled.div`
   right: 0;
   bottom: 0;
   width: 400px;
+  z-index: 10;
 `;
 
 const SBox = styled.div`
@@ -31,6 +32,7 @@ const SBox = styled.div`
   position: absolute;
   width: 100%;
   bottom: 0;
+  z-index: 10000;
 
   &.open {
     height: 500px;


### PR DESCRIPTION
Give the survey a z-index to keep in front of the select menu if open. 10 is enough to be in front of the select, checking the delete modal it is using 1000 so this will keep the survey behind modals if open