### PR TITLE
fix: set maximum length of team name to 255

### DIFF
--- a/app/form-components/team-form/CreateTeamForm.tsx
+++ b/app/form-components/team-form/CreateTeamForm.tsx
@@ -78,7 +78,7 @@ function CreateTeamForm({ onSubmit, alert }: Props) {
 
   return (
     <div>
-      <Input label="Team Name" onChange={handleNameChange} value={teamName} />
+      <Input label="Team Name" onChange={handleNameChange} maxlength="255" value={teamName} />
       {errors && errors.name && <ErrorText>{errors?.name}</ErrorText>}
       <br />
       <strong>Team Members</strong>


### PR DESCRIPTION
When creating a new team, entering a team name larger than 255 characters causes a 422 error. (Shows up as 503 in screen message). The actual error message shows:

```json
{
"success": false,
"message": "value too long for type character varying(255)"
}
```
This fix sets `maxlength="255"` for the Team Name input field.