### PR TITLE
fix: outlook bug

### DIFF
--- a/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
+++ b/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
@@ -346,6 +346,7 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
     integration with GitHub
   </li>
 </ol>
+<div style="display: none">&nbsp;</div>
   <p>
   If you have any questions, please contact us by
   <a href="https://chat.developer.gov.bc.ca/channel/sso" target="_blank" title="Rocket Chat" rel="noreferrer">
@@ -508,6 +509,7 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
     integration with GitHub
   </li>
 </ol>
+<div style="display: none">&nbsp;</div>
   <p>
   If you have any questions, please contact us by
   <a href="https://chat.developer.gov.bc.ca/channel/sso" target="_blank" title="Rocket Chat" rel="noreferrer">
@@ -676,6 +678,7 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
     integration with GitHub
   </li>
 </ol>
+<div style="display: none">&nbsp;</div>
   <p>
   If you have any questions, please contact us by
   <a href="https://chat.developer.gov.bc.ca/channel/sso" target="_blank" title="Rocket Chat" rel="noreferrer">
@@ -1137,6 +1140,7 @@ exports[`Email template snapshots Should return the expected email for UPDATE_IN
     integration with GitHub
   </li>
 </ol>
+<div style="display: none">&nbsp;</div>
   <p>
   If you have any questions, please contact us by
   <a href="https://chat.developer.gov.bc.ca/channel/sso" target="_blank" title="Rocket Chat" rel="noreferrer">
@@ -1305,6 +1309,7 @@ exports[`Email template snapshots Should return the expected email for UPDATE_IN
     integration with GitHub
   </li>
 </ol>
+<div style="display: none">&nbsp;</div>
   <p>
   If you have any questions, please contact us by
   <a href="https://chat.developer.gov.bc.ca/channel/sso" target="_blank" title="Rocket Chat" rel="noreferrer">

--- a/lambda/shared/templates/create-github-bottom.html
+++ b/lambda/shared/templates/create-github-bottom.html
@@ -26,3 +26,4 @@
     integration with GitHub
   </li>
 </ol>
+<div style="display: none">&nbsp;</div>


### PR DESCRIPTION
fix for email format bug in outlook, outlook adds another empty \<li\> if there is no html element after a list, adding in an empty div at the end fixes it.