### PR TITLE
fix: remove old email and replace with sso team

### DIFF
--- a/app/layout/Layout.tsx
+++ b/app/layout/Layout.tsx
@@ -189,7 +189,7 @@ function Layout({ children, session, user, onLoginClick, onLogoutClick }: any) {
           <FontAwesomeIcon size="2x" icon={faCommentDots} />
         </a>
         &nbsp;&nbsp;
-        <a href="mailto:Vardhman.Shankar@gov.bc.ca" title="SSO Team">
+        <a href="mailto:bcgov.sso@gov.bc.ca" title="SSO Team">
           <FontAwesomeIcon size="2x" icon={faEnvelope} />
         </a>
         &nbsp;&nbsp;


### PR DESCRIPTION
Application was still showing `<a href="mailto:Vardhman.Shankar@gov.bc.ca" title="SSO Team">` in Layout.tsx.
Changed the email address to the SSO Team email.