### PR TITLE
feat: add testids for team creation

### DIFF
--- a/app/form-components/team-form/TeamMembersForm.tsx
+++ b/app/form-components/team-form/TeamMembersForm.tsx
@@ -199,13 +199,23 @@ function TeamMembersForm({ errors, members, setMembers, allowDelete = true, curr
                 <option value="admin">Admin</option>
               </Dropdown>
               {i >= 0 && allowDelete && (
-                <Icon icon={faMinusCircle} onClick={() => handleMemberDelete(i)} title="Delete" />
+                <Icon
+                  icon={faMinusCircle}
+                  onClick={() => handleMemberDelete(i)}
+                  title="Delete"
+                  data-testid="delete-user-role"
+                />
               )}
             </MemberContainer>
           </>
         ))}
         <AddMemberButton onClick={handleAddMember}>
-          <FontAwesomeIcon style={{ color: '#006fc4' }} icon={faPlusCircle} title="Add Item" />
+          <FontAwesomeIcon
+            style={{ color: '#006fc4' }}
+            icon={faPlusCircle}
+            title="Add Item"
+            data-testid="add-user-role"
+          />
           <span>Add another team member</span>
         </AddMemberButton>
       </MembersSection>


### PR DESCRIPTION
Adding 2 new test ids for the teams creation window to easier address the "add" and the "delete" icons shown.