### PR TITLE
fix: make testids unique

### DIFF
--- a/app/components/CenteredModal.tsx
+++ b/app/components/CenteredModal.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Grid as SpinnerGrid } from 'react-loader-spinner';
 import { faExclamationTriangle, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { Button } from '@bcgov-sso/common-react-components';
+import kebabCase from 'lodash.kebabcase';
 
 const StyledModal = styled(Modal)`
   display: flex;
@@ -88,6 +89,8 @@ const CenteredModal = ({
   const showButtons = showCancel || showConfirm;
   let cancelButtonVariant = 'bcSecondary';
   let confirmButtonVariant = 'bcPrimary';
+  let dataTestId = 'confirm-delete-' + kebabCase(title);
+  let dataTestIdCancel = 'cancel-' + kebabCase(title);
 
   switch (buttonStyle) {
     case 'bcgov':
@@ -130,12 +133,12 @@ const CenteredModal = ({
         {showButtons && (
           <ButtonContainer buttonAlign={buttonAlign}>
             {showCancel && (
-              <Button variant={cancelButtonVariant} onClick={handleCancel} type="button">
+              <Button variant={cancelButtonVariant} onClick={handleCancel} type="button" data-testid={dataTestIdCancel}>
                 Cancel
               </Button>
             )}
             <Button
-              data-testid="confirm-delete"
+              data-testid={dataTestId}
               onClick={handleConfirm}
               variant={confirmButtonVariant}
               type="button"

--- a/app/jest/my-dashboard/my-projects/integrationList.test.tsx
+++ b/app/jest/my-dashboard/my-projects/integrationList.test.tsx
@@ -58,7 +58,7 @@ describe('Integration list', () => {
     });
 
     await waitFor(async () => {
-      fireEvent.click(await screen.findByTestId('confirm-delete'));
+      fireEvent.click(await screen.findByTestId('confirm-delete-confirm-deletion'));
     });
     await waitFor(() => {
       expect(spyDeleteRequest).toHaveBeenCalledTimes(1);

--- a/app/jest/my-dashboard/my-teams/integrations.test.tsx
+++ b/app/jest/my-dashboard/my-teams/integrations.test.tsx
@@ -188,8 +188,8 @@ describe('Integrations tab', () => {
     const actionDeleteButton = screen.getAllByTestId('action-button-delete');
     fireEvent.click(actionDeleteButton[0]);
     expect(screen.findByTitle('Confirm Deletion'));
-    const confirmDeleteButton = screen.getAllByTestId('confirm-delete');
-    fireEvent.click(confirmDeleteButton[1]);
+    const confirmDeleteButton = screen.getAllByTestId('confirm-delete-confirm-deletion');
+    fireEvent.click(confirmDeleteButton[0]);
     expect(deleteRequest).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/jest/my-dashboard/my-teams/members.test.tsx
+++ b/app/jest/my-dashboard/my-teams/members.test.tsx
@@ -156,8 +156,8 @@ describe('Members tab', () => {
     await waitFor(() => {
       expect(screen.getByTitle('Delete Team Member'));
     });
-    const confirmDeleteButton = await screen.findAllByTestId('confirm-delete');
-    fireEvent.click(confirmDeleteButton[2]);
+    const confirmDeleteButton = await screen.findAllByTestId('confirm-delete-delete-team-member');
+    fireEvent.click(confirmDeleteButton[0]);
     await waitFor(() => {
       expect(deleteTeamMember).toHaveBeenCalledTimes(1);
     });

--- a/app/jest/ssoDashboard.test.tsx
+++ b/app/jest/ssoDashboard.test.tsx
@@ -161,8 +161,8 @@ describe('SSO Dashboard', () => {
     await waitFor(() => {
       expect(screen.getByTitle('Confirm Deletion')).toBeInTheDocument();
     });
-    const confirmDeleteButton = screen.getAllByTestId('confirm-delete');
-    fireEvent.click(confirmDeleteButton[1]);
+    const confirmDeleteButton = screen.getAllByTestId('confirm-delete-confirm-deletion');
+    fireEvent.click(confirmDeleteButton[0]);
     await waitFor(() => {
       expect(deleteRequest).toHaveBeenCalled();
     });


### PR DESCRIPTION
With the current structure of the application, we end up with many duplicate testids.
This is because the modal dialogs are being used in multiple places and the testids are not unique.
This PR fixes that by adding a postfix to the testids that is unique to the component (basically the title of the dialog) that is using the modal dialog.

fix: ssoteam 1179 eliminate duplicate testids 