### PR TITLE
fix: improve the validation when adding a new email

### DIFF
--- a/app/form-components/team-form/TeamMembersForm.tsx
+++ b/app/form-components/team-form/TeamMembersForm.tsx
@@ -236,6 +236,7 @@ export const validateTeam = (team: { name: string; members: User[] }) => {
     errors.name = 'Please enter a name';
   }
 
+  // Validation for member emails: they need to be present and valid.
   team.members.forEach((member: User, i: number) => {
     if (!member.idirEmail) errors.members[i] = 'Please enter an email';
     else if (!validator.isEmail(member.idirEmail)) errors.members[i] = 'Please enter a valid email';

--- a/app/form-components/team-form/TeamMembersForm.tsx
+++ b/app/form-components/team-form/TeamMembersForm.tsx
@@ -237,7 +237,8 @@ export const validateTeam = (team: { name: string; members: User[] }) => {
   }
 
   team.members.forEach((member: User, i: number) => {
-    if (!member.idirEmail || !validator.isEmail(member.idirEmail)) errors.members[i] = 'Please enter an email';
+    if (!member.idirEmail) errors.members[i] = 'Please enter an email';
+    else if (!validator.isEmail(member.idirEmail)) errors.members[i] = 'Please enter a valid email';
   });
 
   const hasError = errors.name || errors.members.length > 0;


### PR DESCRIPTION
The current validation when adding a new email always presents the same error message on failure.
Failure modes are:
* Email not there
* Email invalid

If either one is true the the message: **'Please enter an email'** is shown.
This fix will distinguish between the 2 error situations and in case of a invalid email it will show: **'Please enter a valid email'**
