### PR TITLE
fix: add proper favicon

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -219,7 +219,7 @@ function MyApp({ Component, pageProps }: AppProps) {
               <Head>
                 <html lang="en" />
                 <title>Common Hosted Single Sign-on (CSS)</title>
-                <link rel="icon" href="/bootstrap-theme/dist/images/bcid-favicon-32x32.png" />
+                <link rel="icon" href="bcid-favicon-32x32.png" />
               </Head>
               <Component {...pageProps} session={session} onLoginClick={handleLogin} onLogoutClick={handleLogout} />
             </Layout>

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -219,6 +219,7 @@ function MyApp({ Component, pageProps }: AppProps) {
               <Head>
                 <html lang="en" />
                 <title>Common Hosted Single Sign-on (CSS)</title>
+                <link rel="icon" href="/bootstrap-theme/dist/images/bcid-favicon-32x32.png" />
               </Head>
               <Component {...pageProps} session={session} onLoginClick={handleLogin} onLogoutClick={handleLogout} />
             </Layout>

--- a/app/pages/faq.tsx
+++ b/app/pages/faq.tsx
@@ -10,7 +10,6 @@ export default function FAQ() {
     <>
       <Head>
         <meta name="description" content="The request process workflow tool for the RedHat SSO Dev Exchange service" />
-        <link rel="icon" href="/bcid-favicon-32x32.png" />
       </Head>
       <ResponsiveContainer rules={defaultRules}>
         <Grid cols={2} gutter={[5, 2]}>

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -107,7 +107,6 @@ export default function Home({ onLoginClick }: PageProps) {
     <>
       <Head>
         <meta name="description" content="The request process workflow tool for the RedHat SSO Dev Exchange service" />
-        <link rel="icon" href="/bcid-favicon-32x32.png" />
       </Head>
       <ResponsiveContainer rules={defaultRules}>
         <Grid cols={2} gutter={[5, 2]}>


### PR DESCRIPTION
It bothered me there was not a proper favicon shown.
Turned out that in the code it was misconfigured (wrong spots).
It turns out that we have the bc favicon on githib.io at: https://bcgov.github.io/bootstrap-theme/dist/images/bcid-favicon-32x32.png

So by adding this to the code as: /bootstrap-theme/dist/images/bcid-favicon-32x32.png
we'll now have the official favicon.