### PR TITLE
fix: set the favicon to bootstrap theme

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -219,7 +219,7 @@ function MyApp({ Component, pageProps }: AppProps) {
               <Head>
                 <html lang="en" />
                 <title>Common Hosted Single Sign-on (CSS)</title>
-                <link rel="icon" href="/bcid-favicon-32x32.png" />
+                <link rel="icon" href="/bootstrap-theme/dist/images/bcid-favicon-32x32.png" />
               </Head>
               <Component {...pageProps} session={session} onLoginClick={handleLogin} onLogoutClick={handleLogout} />
             </Layout>


### PR DESCRIPTION
Setting the favicon to [/bootstrap-theme/dist/images/bcid-favicon-32x32.png](https://bcgov.github.io/bootstrap-theme/dist/images/bcid-favicon-32x32.png) because the way the application deals with its base URL causes issue with relative links.

So for the time being we can fix this, with the notion that there might be a future need to work on how the base path operates in the application.