### PR TITLE
fix: expand validation team members form

### DIFF
--- a/app/form-components/team-form/CreateTeamForm.tsx
+++ b/app/form-components/team-form/CreateTeamForm.tsx
@@ -48,8 +48,9 @@ function CreateTeamForm({ onSubmit, alert }: Props) {
   };
 
   const handleCreate = async () => {
+    const adminUser = session as LoggedInUser;
     const team = { name: teamName, members };
-    const [hasError, errors] = validateTeam(team);
+    const [hasError, errors] = validateTeam(team, adminUser.email as string);
     if (hasError) return setErrors(errors);
 
     setLoading(true);

--- a/app/form-components/team-form/TeamMembersForm.tsx
+++ b/app/form-components/team-form/TeamMembersForm.tsx
@@ -9,6 +9,8 @@ import { User, LoggedInUser } from 'interfaces/team';
 import ErrorText from 'components/ErrorText';
 import Link from '@button-inc/bcgov-theme/Link';
 
+let adminUser = ''; // Save admin user for later form validation.
+
 const Container = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -177,7 +179,7 @@ function TeamMembersForm({ errors, members, setMembers, allowDelete = true, curr
         </EmailAddrValidHeader>
         {currentUser && (
           <MemberContainer>
-            <Input value={currentUser?.email || ''} readOnly />
+            <Input value={(adminUser = currentUser?.email || '')} readOnly />
             <Dropdown label="Role" disabled value={'admin'} readOnlyRole={true}>
               <option value="admin">Admin</option>
             </Dropdown>
@@ -241,7 +243,7 @@ export const validateTeam = (team: { name: string; members: User[] }) => {
     else if (!validator.isEmail(member.idirEmail)) errors.members[i] = 'Please enter a valid email';
     else {
       let result = team.members.filter((email) => email.idirEmail === member.idirEmail).length;
-      if (result > 1) errors.members[i] = 'Please use unique email';
+      if (result > 1 || member.idirEmail === adminUser) errors.members[i] = 'Please use unique email';
     }
   });
 

--- a/app/form-components/team-form/TeamMembersForm.tsx
+++ b/app/form-components/team-form/TeamMembersForm.tsx
@@ -9,8 +9,6 @@ import { User, LoggedInUser } from 'interfaces/team';
 import ErrorText from 'components/ErrorText';
 import Link from '@button-inc/bcgov-theme/Link';
 
-let adminUser = ''; // Save admin user for later form validation.
-
 const Container = styled.div`
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -93,10 +91,6 @@ interface Props {
 }
 
 function TeamMembersForm({ errors, members, setMembers, allowDelete = true, currentUser = null }: Props) {
-  // Set adminUser to currentUser's email, if currentUser is not null
-  if (currentUser?.email) {
-    adminUser = currentUser.email;
-  }
   const handleAddMember = () => {
     setMembers([
       ...members,
@@ -235,7 +229,7 @@ function TeamMembersForm({ errors, members, setMembers, allowDelete = true, curr
   );
 }
 
-export const validateTeam = (team: { name: string; members: User[] }) => {
+export const validateTeam = (team: { name: string; members: User[] }, adminUser: string) => {
   const errors: any = { name: null, members: [] };
 
   if (!team.name) {

--- a/app/form-components/team-form/TeamMembersForm.tsx
+++ b/app/form-components/team-form/TeamMembersForm.tsx
@@ -94,7 +94,7 @@ interface Props {
 
 function TeamMembersForm({ errors, members, setMembers, allowDelete = true, currentUser = null }: Props) {
   // Set adminUser to currentUser's email, if currentUser is not null
-  if (currentUser && currentUser.email) {
+  if (currentUser?.email) {
     adminUser = currentUser.email;
   }
   const handleAddMember = () => {

--- a/app/form-components/team-form/TeamMembersForm.tsx
+++ b/app/form-components/team-form/TeamMembersForm.tsx
@@ -93,6 +93,10 @@ interface Props {
 }
 
 function TeamMembersForm({ errors, members, setMembers, allowDelete = true, currentUser = null }: Props) {
+  // Set adminUser to currentUser's email, if currentUser is not null
+  if (currentUser && currentUser.email) {
+    adminUser = currentUser.email;
+  }
   const handleAddMember = () => {
     setMembers([
       ...members,
@@ -179,7 +183,7 @@ function TeamMembersForm({ errors, members, setMembers, allowDelete = true, curr
         </EmailAddrValidHeader>
         {currentUser && (
           <MemberContainer>
-            <Input value={(adminUser = currentUser?.email || '')} readOnly />
+            <Input value={currentUser?.email || ''} readOnly />
             <Dropdown label="Role" disabled value={'admin'} readOnlyRole={true}>
               <option value="admin">Admin</option>
             </Dropdown>

--- a/app/jest/my-dashboard/my-teams/teamList.test.tsx
+++ b/app/jest/my-dashboard/my-teams/teamList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within, getByText } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, getByText, getAllByText } from '@testing-library/react';
 import TeamList from 'page-partials/my-dashboard/TeamList';
 import { createTeam, deleteTeam, editTeamName } from 'services/team';
 import { SessionContext } from '@app/pages/_app';
@@ -93,7 +93,8 @@ describe('Team List', () => {
       expect(screen.getByDisplayValue('sampleMember01@gov.bc.ca')).toBeInTheDocument();
     });
 
-    expect(getByText(container, 'Admin', { selector: 'option' }));
+    // With user from context, should be two now
+    expect(getAllByText(container, 'Admin', { selector: 'option' }).length).toBe(2);
     expect(getByText(container, 'Member', { selector: 'option' }));
     expect(getByRole('link', 'View a detailed breakdown of roles on our wiki page')).toHaveAttribute('href', HYPERLINK);
 

--- a/app/jest/my-dashboard/my-teams/teamList.test.tsx
+++ b/app/jest/my-dashboard/my-teams/teamList.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, getByText } from '@testing-library/react';
 import TeamList from 'page-partials/my-dashboard/TeamList';
 import { createTeam, deleteTeam, editTeamName } from 'services/team';
+import { SessionContext } from '@app/pages/_app';
 
 function TeamListComponent() {
   return (
@@ -65,7 +66,13 @@ jest.mock('services/team', () => ({
 
 describe('Team List', () => {
   it('Should match the expected button name, and testing on all text-input-box, drop-down-box, hyperlink, and button functionality in the modal', async () => {
-    render(<TeamListComponent />);
+    const { container } = render(
+      <SessionContext.Provider
+        value={{ session: { email: 'test@email.com' }, user: { idirEmail: 'test@email.com', role: '' } }}
+      >
+        <TeamListComponent />
+      </SessionContext.Provider>,
+    );
 
     const createTeamButton = getByRole('button', '+ Create a New Team');
     expect(createTeamButton).toBeInTheDocument();
@@ -86,8 +93,8 @@ describe('Team List', () => {
       expect(screen.getByDisplayValue('sampleMember01@gov.bc.ca')).toBeInTheDocument();
     });
 
-    expect(getByRole('option', 'Admin'));
-    expect(getByRole('option', 'Member'));
+    expect(getByText(container, 'Admin', { selector: 'option' }));
+    expect(getByText(container, 'Member', { selector: 'option' }));
     expect(getByRole('link', 'View a detailed breakdown of roles on our wiki page')).toHaveAttribute('href', HYPERLINK);
 
     fireEvent.click(screen.getByRole('img', { name: 'Add Item' }));

--- a/app/page-partials/my-dashboard/TeamInfoTabs/index.tsx
+++ b/app/page-partials/my-dashboard/TeamInfoTabs/index.tsx
@@ -310,7 +310,7 @@ function TeamInfoTabs({ alert, currentUser, team, loadTeams }: Props) {
   };
 
   const onConfirmAdd = async () => {
-    const [hasError, errors] = validateTeam({ name: team.name, members: tempMembers });
+    const [hasError, errors] = validateTeam({ name: team.name, members: tempMembers }, currentUser.email);
     if (hasError) {
       setErrors(errors);
       return;


### PR DESCRIPTION
Added a validation so that user do not accidently add the admin email again when creating a new team. We already had the validation on duplicate team members, but we needed to validate the admin (first team member in the list) email as well.