### PR TITLE
feat: testimonials

### DIFF
--- a/app/components/Carousel.tsx
+++ b/app/components/Carousel.tsx
@@ -72,8 +72,8 @@ export default function Carousel({ viewableItems, children }: Readonly<Props>) {
     <Container viewableItems={viewableItems} index={carouselIndex} totalItems={children.length}>
       <div className="all-items">
         <div className="displayed-items">
-          {children.map((child, i) => (
-            <div className="item-container" key={i}>
+          {children.map((child) => (
+            <div className="item-container" key={(child as any).key}>
               {child}
             </div>
           ))}

--- a/app/components/Carousel.tsx
+++ b/app/components/Carousel.tsx
@@ -36,13 +36,13 @@ const Container = styled.div<{ viewableItems: number; index: number; totalItems:
     .arrow-left {
       margin-right: 0.5em;
       cursor: ${(props) => (props.index === 0 ? 'not-allowed' : 'pointer')};
-      color: ${(props) => (props.index === 0 ? 'grey' : 'black')};
+      color: ${(props) => (props.index === 0 ? 'grey' : '#036')};
     }
 
     .arrow-right {
       margin-left: 0.5em;
       cursor: ${(props) => (props.index === props.totalItems - props.viewableItems ? 'not-allowed' : 'pointer')};
-      color: ${(props) => (props.index === props.totalItems - props.viewableItems ? 'grey' : 'black')};
+      color: ${(props) => (props.index === props.totalItems - props.viewableItems ? 'grey' : '#036')};
     }
   }
 `;

--- a/app/components/Carousel.tsx
+++ b/app/components/Carousel.tsx
@@ -47,7 +47,7 @@ const Container = styled.div<{ viewableItems: number; index: number; totalItems:
   }
 `;
 
-export default function Carousel({ viewableItems, children }: Props) {
+export default function Carousel({ viewableItems, children }: Readonly<Props>) {
   const [carouselIndex, setCarouselIndex] = useState(0);
   const { width } = useWindowDimensions();
 
@@ -72,8 +72,10 @@ export default function Carousel({ viewableItems, children }: Props) {
     <Container viewableItems={viewableItems} index={carouselIndex} totalItems={children.length}>
       <div className="all-items">
         <div className="displayed-items">
-          {children.map((child) => (
-            <div className="item-container">{child}</div>
+          {children.map((child, i) => (
+            <div className="item-container" key={i}>
+              {child}
+            </div>
           ))}
         </div>
       </div>

--- a/app/components/Carousel.tsx
+++ b/app/components/Carousel.tsx
@@ -1,0 +1,98 @@
+import { ReactNode, useEffect, useState } from 'react';
+import styled from 'styled-components';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import useWindowDimensions from '@app/hooks/useWindowDimensions';
+
+interface Props {
+  viewableItems: number;
+  children: ReactNode[];
+}
+
+const Container = styled.div<{ viewableItems: number; index: number; totalItems: number }>`
+  width: 100%;
+  .all-items {
+    padding: 1em 0;
+    width: 100%;
+    overflow-x: hidden;
+    white-space: nowrap;
+    .displayed-items {
+      transform: translate(-${(props) => (100 / props.viewableItems) * props.index}%);
+      transition: transform 400ms ease-in-out;
+      .item-container {
+        display: inline-block;
+        vertical-align: top;
+        width: calc(100% / ${(props) => props.viewableItems});
+        padding: 0 0.5em;
+        white-space: wrap;
+      }
+    }
+  }
+
+  .controls {
+    text-align: center;
+    margin: 1em 0;
+
+    .arrow-left {
+      margin-right: 0.5em;
+      cursor: ${(props) => (props.index === 0 ? 'not-allowed' : 'pointer')};
+      color: ${(props) => (props.index === 0 ? 'grey' : 'black')};
+    }
+
+    .arrow-right {
+      margin-left: 0.5em;
+      cursor: ${(props) => (props.index === props.totalItems - props.viewableItems ? 'not-allowed' : 'pointer')};
+      color: ${(props) => (props.index === props.totalItems - props.viewableItems ? 'grey' : 'black')};
+    }
+  }
+`;
+
+export default function Carousel({ viewableItems, children }: Props) {
+  const [carouselIndex, setCarouselIndex] = useState(0);
+  const { width } = useWindowDimensions();
+
+  const moveCarousel = (direction: 'left' | 'right') => {
+    if (direction === 'left') {
+      if (carouselIndex <= 0) return;
+      setCarouselIndex(carouselIndex - 1);
+    } else {
+      if (carouselIndex >= children.length - viewableItems) return;
+      setCarouselIndex(carouselIndex + 1);
+    }
+  };
+
+  useEffect(() => {
+    // Adjust index if browser width changes
+    if (carouselIndex >= children.length - viewableItems) {
+      setCarouselIndex(children.length - viewableItems);
+    }
+  }, [width]);
+
+  return (
+    <Container viewableItems={viewableItems} index={carouselIndex} totalItems={children.length}>
+      <div className="all-items">
+        <div className="displayed-items">
+          {children.map((child) => (
+            <div className="item-container">{child}</div>
+          ))}
+        </div>
+      </div>
+      {children.length > viewableItems && (
+        <div className="controls">
+          <FontAwesomeIcon
+            icon={faChevronLeft}
+            size="2x"
+            className="arrow arrow-left"
+            onClick={() => moveCarousel('left')}
+          />
+          <FontAwesomeIcon
+            icon={faChevronRight}
+            size="2x"
+            className="arrow arrow-right"
+            onClick={() => moveCarousel('right')}
+          />
+        </div>
+      )}
+    </Container>
+  );
+}

--- a/app/components/Testimonial.tsx
+++ b/app/components/Testimonial.tsx
@@ -54,7 +54,7 @@ const HalfStar = () => {
   );
 };
 
-export default function Testimonial({ testimonial }: Props) {
+export default function Testimonial({ testimonial }: Readonly<Props>) {
   const hasHalfRating = testimonial.rating % 1 === 0.5;
 
   const ratings = Array.from(Array(Math.floor(testimonial.rating)).keys());

--- a/app/components/Testimonial.tsx
+++ b/app/components/Testimonial.tsx
@@ -1,0 +1,84 @@
+import { ITestimonial } from '@app/interfaces/Testimonial';
+import styled from 'styled-components';
+import { faStar, faStarHalf } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+
+interface Props {
+  testimonial: ITestimonial;
+}
+
+const Card = styled.div`
+  border-radius: 1em;
+  background: #f2f8ff;
+  padding: 1em;
+  box-shadow: rgba(60, 64, 67, 0.3) 0px 1px 2px 0px, rgba(60, 64, 67, 0.15) 0px 2px 6px 2px;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .ratings {
+    display: flex;
+    margin-bottom: 0.5em;
+  }
+
+  .author {
+    .name {
+      font-weight: bold;
+    }
+  }
+
+  .seperator {
+    margin: 1em 0;
+    padding: 0;
+    background-color: black;
+    height: 1px;
+  }
+`;
+
+const MAX_RATING = 5;
+
+const HalfStarContainer = styled.span`
+  position: relative;
+  * {
+    position: absolute;
+  }
+`;
+
+const HalfStar = () => {
+  return (
+    <HalfStarContainer>
+      <FontAwesomeIcon color="gold" icon={faStarHalf} size="lg" fill="grey" />
+      <FontAwesomeIcon color="grey" icon={faStarHalf} size="lg" transform={{ flipX: true }} />
+    </HalfStarContainer>
+  );
+};
+
+export default function Testimonial({ testimonial }: Props) {
+  const hasHalfRating = testimonial.rating % 1 === 0.5;
+
+  const ratings = Array.from(Array(Math.floor(testimonial.rating)).keys());
+  const emptyRatings = Array.from(Array(MAX_RATING - Math.ceil(testimonial.rating)).keys());
+
+  return (
+    <Card>
+      <div className="ratings">
+        {ratings.map((i) => (
+          <FontAwesomeIcon key={i} color="gold" icon={faStar} size="lg" />
+        ))}
+        {hasHalfRating && <HalfStar />}
+        {emptyRatings.map((i) => (
+          <FontAwesomeIcon key={i} color="grey" icon={faStar} size="lg" />
+        ))}
+      </div>
+
+      <div className="body">{testimonial.body}</div>
+
+      <div className="author">
+        <hr className="seperator" />
+        <span className="name">{testimonial.author.name}</span> |{' '}
+        <span className="title">{testimonial.author.title}</span>
+      </div>
+    </Card>
+  );
+}

--- a/app/hooks/useWindowDimensions.tsx
+++ b/app/hooks/useWindowDimensions.tsx
@@ -1,0 +1,24 @@
+import { useState, useEffect } from 'react';
+
+function getWindowDimensions() {
+  const { innerWidth: width, innerHeight: height } = window;
+  return {
+    width,
+    height,
+  };
+}
+
+export default function useWindowDimensions() {
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowDimensions(getWindowDimensions());
+    }
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  return windowDimensions;
+}

--- a/app/interfaces/Testimonial.ts
+++ b/app/interfaces/Testimonial.ts
@@ -1,4 +1,5 @@
 export interface ITestimonial {
+  id: number;
   author: {
     name: string;
     title: string;

--- a/app/interfaces/Testimonial.ts
+++ b/app/interfaces/Testimonial.ts
@@ -1,0 +1,8 @@
+export interface ITestimonial {
+  author: {
+    name: string;
+    title: string;
+  };
+  body: string;
+  rating: number;
+}

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -126,7 +126,7 @@ const WhatsNew = styled.div`
   }
 `;
 
-export default function Home({ onLoginClick }: PageProps) {
+export default function Home({ onLoginClick }: Readonly<PageProps>) {
   const { width } = useWindowDimensions();
   return (
     <>
@@ -194,7 +194,7 @@ export default function Home({ onLoginClick }: PageProps) {
           <Grid.Row collapse="800">
             <Carousel viewableItems={width > 1200 ? 3 : 2}>
               {testimonials.map((testimonial) => (
-                <Testimonial testimonial={testimonial} />
+                <Testimonial testimonial={testimonial} key={testimonial.id} />
               ))}
             </Carousel>
           </Grid.Row>

--- a/app/pages/index.tsx
+++ b/app/pages/index.tsx
@@ -12,7 +12,11 @@ import { Accordion } from '@bcgov-sso/common-react-components';
 import FaqItems from 'page-partials/faq/FaqItems';
 import { LANDING_HEADER_FONT, LARGE_BUTTON_FONT_SIZE } from 'styles/theme';
 import GithubDiscussions from '@app/components/GithubDiscussions';
-import { wikiURL, docusaurusURL } from '@app/utils/constants';
+import { wikiURL, docusaurusURL, testimonials } from '@app/utils/constants';
+import Testimonial from 'components/Testimonial';
+import Carousel from 'components/Carousel';
+import useWindowDimensions from '@app/hooks/useWindowDimensions';
+
 interface PanelProps {
   marginLeft?: boolean;
   marginRight?: boolean;
@@ -123,6 +127,7 @@ const WhatsNew = styled.div`
 `;
 
 export default function Home({ onLoginClick }: PageProps) {
+  const { width } = useWindowDimensions();
   return (
     <>
       <Head>
@@ -183,6 +188,19 @@ export default function Home({ onLoginClick }: PageProps) {
           </Grid.Row>
         </Grid>
       </ResponsiveContainer>
+
+      <ResponsiveContainer rules={defaultRules}>
+        <Grid cols={2} gutter={[5, 2]}>
+          <Grid.Row collapse="800">
+            <Carousel viewableItems={width > 1200 ? 3 : 2}>
+              {testimonials.map((testimonial) => (
+                <Testimonial testimonial={testimonial} />
+              ))}
+            </Carousel>
+          </Grid.Row>
+        </Grid>
+      </ResponsiveContainer>
+
       <WhatsNew>
         <ResponsiveContainer rules={defaultRules} style={{ marginTop: '0px' }}>
           <Grid cols={6} gutter={[5, 2]}>

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -76,6 +76,7 @@ export const preservedClaims = [
 
 export const testimonials: ITestimonial[] = [
   {
+    id: 1,
     author: {
       name: 'Wim Mulder',
       title: 'Senior Technical Analyst, IM/IT Enterprise Projects',
@@ -84,6 +85,7 @@ export const testimonials: ITestimonial[] = [
     rating: 5,
   },
   {
+    id: 2,
     author: {
       name: 'Aditya Sharma',
       title: 'Quality Assurance Lead',
@@ -92,6 +94,7 @@ export const testimonials: ITestimonial[] = [
     rating: 5,
   },
   {
+    id: 3,
     author: {
       name: 'Garry Wong',
       title: 'Senior Product Owner',
@@ -100,6 +103,7 @@ export const testimonials: ITestimonial[] = [
     rating: 4.5,
   },
   {
+    id: 4,
     author: {
       name: 'Jessica Wade',
       title: 'Senior Product Manager, Digital Delivery',

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -1,3 +1,4 @@
+import { ITestimonial } from '@app/interfaces/Testimonial';
 import { EnvironmentOption, ErrorMessages } from '@app/interfaces/form';
 
 export const createTeamModalId = `create-team-modal`;
@@ -71,4 +72,39 @@ export const preservedClaims = [
   'email',
   'scope',
   'at_hash',
+];
+
+export const testimonials: ITestimonial[] = [
+  {
+    author: {
+      name: 'Wim Mulder',
+      title: 'Senior Technical Analyst, IM/IT Enterprise Projects',
+    },
+    body: 'The Common Hosted Single Sign-On (CSS) service has streamlined login access for both Government staff and contractors to our Snow Avalanche Weather System (SAWSx), with its easy integration requiring minimal code. The team provides exceptional customer service, swiftly addressing a critical issue on our end. Grateful for the prompt assistance and seamless experience provided by the team.',
+    rating: 5,
+  },
+  {
+    author: {
+      name: 'Aditya Sharma',
+      title: 'Quality Assurance Lead',
+    },
+    body: "It was a breeze to integrate our SAAS platform, BrowserStack, with Single Sign-On with the expert assistance of the SSO team.  The CSS app's flexibility eased integration challenges, allowing seamless Dev and Test setups. The responsive support received, especially in overcoming signed assertion hurdles, showcased the team's expertise and contributed to a smooth experience, noticeably enhancing our login process.",
+    rating: 5,
+  },
+  {
+    author: {
+      name: 'Garry Wong',
+      title: 'Senior Product Owner',
+    },
+    body: 'Having collaborated with the CSS team across multiple projects, their responsiveness to technical inquiries and support during onboarding has been invaluable. The user-friendly CSS Dashboard, technical support via RocketChat, and regular open demo sessions have greatly contributed to our collaborative community. With acknowledgment within 15 minutes and resolutions ranging from 15 minutes to the same day, the service has been consistently solid.',
+    rating: 4.5,
+  },
+  {
+    author: {
+      name: 'Jessica Wade',
+      title: 'Senior Product Manager, Digital Delivery',
+    },
+    body: 'Our team has had a really positive experience working with the single-sign on keycloak service. We were able to work with Zorin and her team to get us set up in a custom realm which suited the needs at BC Parks. Since then we have been able to integrate BCeID and BC Services Card and are managing roles for up to 5 different products through the tool and enabled easy log ins for our users so they can see what is relevant to them.',
+    rating: 4.5,
+  },
 ];

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -96,7 +96,7 @@ export const testimonials: ITestimonial[] = [
   {
     id: 3,
     author: {
-      name: 'Garry Wong',
+      name: 'Gary Wong',
       title: 'Senior Product Owner',
     },
     body: 'Having collaborated with the CSS team across multiple projects, their responsiveness to technical inquiries and support during onboarding has been invaluable. The user-friendly CSS Dashboard, technical support via RocketChat, and regular open demo sessions have greatly contributed to our collaborative community. With acknowledgment within 15 minutes and resolutions ranging from 15 minutes to the same day, the service has been consistently solid.',


### PR DESCRIPTION
Add carousel for testimonials. As agreed we are hardcoding them right now, I made it an imported constant so it will be easy to switch to an API call later if we want.

When going over the mockup I realized some of the design was a bit unclear, e.g the testimonials have a title in the design but not in the spreadsheet. There was also a "Lorem Ipsum" top quote, not sure what the content was supposed to be. I still think it looks good though, image below of what is implemented:

![image](https://github.com/bcgov/sso-requests/assets/37274633/52434bde-c653-44a3-8f98-201420c46811)
