### PR TITLE
fix: e2e-smoke-test dependency

### DIFF
--- a/.github/workflows/e2e-smoke-test.yaml
+++ b/.github/workflows/e2e-smoke-test.yaml
@@ -17,6 +17,10 @@ on:
     workflows: ['Build and Deploy GH Pages', 'Terraform']
     types:
       - completed
+  
+  push:
+    branches:
+      - dev
 
 jobs:
   trigger-remote-workflow:

--- a/.github/workflows/e2e-smoke-test.yaml
+++ b/.github/workflows/e2e-smoke-test.yaml
@@ -14,7 +14,7 @@ on:
           - debug
   # Only trigger, when the build workflow succeeded
   workflow_run:
-    workflows: ['Build and Deploy GH Pages']
+    workflows: ['Build and Deploy GH Pages', 'Terraform']
     types:
       - completed
 

--- a/.github/workflows/e2e-smoke-test.yaml
+++ b/.github/workflows/e2e-smoke-test.yaml
@@ -12,9 +12,11 @@ on:
           - info
           - warning
           - debug
-  push:
-    branches:
-      - dev
+  # Only trigger, when the build workflow succeeded
+  workflow_run:
+    workflows: ['Build and Deploy GH Pages']
+    types:
+      - completed
 
 jobs:
   trigger-remote-workflow:


### PR DESCRIPTION
Adding a dependency on the completion of 'Build and Deploy GH Pages'