### PR TITLE
bug: remove the push trigger

### DIFF
--- a/.github/workflows/e2e-smoke-test.yaml
+++ b/.github/workflows/e2e-smoke-test.yaml
@@ -17,10 +17,6 @@ on:
     workflows: ['Build and Deploy GH Pages', 'Terraform']
     types:
       - completed
-  
-  push:
-    branches:
-      - dev
 
 jobs:
   trigger-remote-workflow:


### PR DESCRIPTION
Combining the push trigger with the wait for workflow does not work. The push trigger will fire first, so we are back to square one.