### PR TITLE
chore: cypress update

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,5 +24,7 @@ CODE_OF_CONDUCT.md
 CONTRIBUTING.md
 LICENSE
 *.lock
-node_modules
-.env
+**/node_modules
+**/.env
+**/.next
+**/.terraform

--- a/app/package.json
+++ b/app/package.json
@@ -11,7 +11,8 @@
     "export": "next export",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "docker-build": "next build && next start"
   },
   "dependencies": {
     "@bcgov-sso/common-react-components": "^1.30.1",

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -174,7 +174,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     if (session) {
       const interval = setInterval(async () => {
         const tokenPayload = parseJWTPayload(getTokens().refresh_token);
-        if (Date.now() >= tokenPayload.exp * 1000) {
+        if (Date.now() >= tokenPayload?.exp * 1000) {
           setRefreshTokenState('expired');
           sessionExpiringModalRef.current.close();
           sessionExpiredModalRef.current.open();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     container_name: sso-portal-ui
     image: sso-requests:latest
     entrypoint: yarn
-    command: ['--cwd', './app', 'dev']
+    command: ['--cwd', './app', 'docker-build']
     ports:
       - 3000:3000
     environment:
@@ -84,6 +84,7 @@ services:
       GRAFANA_API_TOKEN: s3cr3t
       GRAFANA_API_URL: https://sso-grafana-sandbox.apps.gold.devops.gov.bc.ca/api
       GOLD_IP_ADDRESS: '142.34.229.4'
+      CYPRESS_RUNNER: 'true'
     networks:
       css-net:
         aliases: [sso-requests-api]

--- a/lambda/app/src/bceid-webservice-proxy/idir.ts
+++ b/lambda/app/src/bceid-webservice-proxy/idir.ts
@@ -1,6 +1,6 @@
 import { createIdirUser } from '../keycloak/users';
 import { ConfidentialClientApplication, IConfidentialClientApplication } from '@azure/msal-node';
-import { MS_GRAPH_URL } from '@lambda-app/utils/constants';
+import { CYPRESS_MOCKED_IDIR_LOOKUP, MS_GRAPH_URL } from '@lambda-app/utils/constants';
 import axios from 'axios';
 
 let msalInstance: IConfidentialClientApplication;
@@ -54,6 +54,9 @@ export async function callAzureGraphApi(endpoint: string) {
 }
 
 export const fuzzySearchIdirEmail = async (email: string) => {
+  if (process.env.CYPRESS_RUNNER) {
+    return CYPRESS_MOCKED_IDIR_LOOKUP;
+  }
   const url = `${MS_GRAPH_URL}/v1.0/users?$filter=startswith(mail,'${email}')&$orderby=userPrincipalName&$count=true&$top=25`;
   return callAzureGraphApi(url).then((res) => res.value?.map((value) => ({ mail: value.mail, id: value.id })));
 };

--- a/lambda/app/src/utils/constants.ts
+++ b/lambda/app/src/utils/constants.ts
@@ -1,1 +1,2 @@
 export const MS_GRAPH_URL = 'https://graph.microsoft.com';
+export const CYPRESS_MOCKED_IDIR_LOOKUP = [{ mail: 'pathfinder.ssotraining2@gov.bc.ca', id: 1 }];


### PR DESCRIPTION
Some small changes for the e2e test:
- Optional IDIR lookup bypass if CYPRESS_RUNNER env var is given. 
- Run the next build of the UI instead of the dev server, requires less resources
- Add optional chaining to the refresh token exp, was causing errors in the headless runner on logout
