### PR TITLE
chore: run e2e tests in ci pipeline

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,7 +36,7 @@ jobs:
         continue-on-error: false
         with:
           summary-title: 'E2E Smoke tests'
-          record: true
+          record: false
           install-command: npm ci
           working-directory: testing
           spec: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,7 +52,6 @@ jobs:
           install-command: npm ci
           working-directory: testing
           spec: |
-            cypress/e2e/**/01-prereq.cy.ts
             cypress/e2e/**/integration-*-*.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,18 +30,25 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'bcgov/sso-requests-e2e'
-      - name: E2E Smoke tests
-        uses: cypress-io/github-action@v6
-        id: smoke
-        continue-on-error: false
-        with:
-          summary-title: 'E2E Smoke tests'
-          record: false
-          install-command: npm ci
-          working-directory: testing
-          spec: |
-            cypress/e2e/smoke/smoke-*-*.cy.ts
-          browser: electron
-          ci-build-id: ${{ github.event.number }}
+      - run: |
+          echo "localhost"
+          curl http://localhost:3000
+          echo "1.0.0.0"
+          curl http://1.0.0.0:3000
+          echo "127.0.0.1"
+          curl http://127.0.0.1:3000
+      # - name: E2E Smoke tests
+      #   uses: cypress-io/github-action@v6
+      #   id: smoke
+      #   continue-on-error: false
+      #   with:
+      #     summary-title: 'E2E Smoke tests'
+      #     record: false
+      #     install-command: npm ci
+      #     working-directory: testing
+      #     spec: |
+      #       cypress/e2e/smoke/smoke-*-*.cy.ts
+      #     browser: electron
+      #     ci-build-id: ${{ github.event.number }}
       # - run: ls
       # - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,9 +20,6 @@ env:
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
-    steps:
-  cypress:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false # https://github.com/cypress-io/github-action/issues/48
     steps:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,22 +30,23 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'bcgov/sso-requests-e2e'
-      - run: |
-          sleep 300
-          echo "127.0.0.1"
-          curl http://127.0.0.1:3000 || true
-      # - name: E2E Smoke tests
-      #   uses: cypress-io/github-action@v6
-      #   id: smoke
-      #   continue-on-error: false
-      #   with:
-      #     summary-title: 'E2E Smoke tests'
-      #     record: false
-      #     install-command: npm ci
-      #     working-directory: testing
-      #     spec: |
-      #       cypress/e2e/smoke/smoke-*-*.cy.ts
-      #     browser: electron
-      #     ci-build-id: ${{ github.event.number }}
-      # - run: ls
-      # - uses: actions/checkout@v4
+      # - run: |
+      #     sleep 300
+      #     echo "127.0.0.1"
+      #     curl http://127.0.0.1:3000 || true
+      - name: E2E Smoke tests
+        uses: cypress-io/github-action@v6
+        id: smoke
+        continue-on-error: false
+        with:
+          summary-title: 'E2E Smoke tests'
+          record: false
+          wait-on: 'http://127.0.0.1:3000'
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/smoke/smoke-*-*.cy.ts
+          browser: electron
+          ci-build-id: ${{ github.event.number }}
+      - run: ls
+      - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ env:
   CYPRESS_guid: ${{ secrets.CYPRESS_GUID }}
   CYPRESS_loginproxy: ${{ secrets.CYPRESS_LOGINPROXY }}
   CYPRESS_siteminder: ${{ secrets.CYPRESS_SITEMINDER }}
-  CYPRESS_host: localhost:3000
+  CYPRESS_host: 'http://127.0.0.1:3000'
   CYPRESS_smoketest: true
 
 jobs:
@@ -47,7 +47,7 @@ jobs:
           install-command: npm ci
           working-directory: testing
           spec: |
-            cypress/e2e/**/integration-*-*.cy.ts
+            cypress/e2e/**/integration-010-*.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
       - run: ls

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -32,11 +32,11 @@ jobs:
           repository: 'bcgov/sso-requests-e2e'
       - run: |
           echo "localhost"
-          curl http://localhost:3000
+          curl http://localhost:3000 || true
           echo "1.0.0.0"
-          curl http://1.0.0.0:3000
+          curl http://1.0.0.0:3000 || true
           echo "127.0.0.1"
-          curl http://127.0.0.1:3000
+          curl http://127.0.0.1:3000 || true
       # - name: E2E Smoke tests
       #   uses: cypress-io/github-action@v6
       #   id: smoke

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,20 @@
+name: Lint PR
+
+on:
+  # pull_request_target:
+  #   types:
+  #     - opened
+  #     - edited
+  #     - synchronize
+  push:
+    branches:
+      - ssoteam-1572
+
+jobs:
+  trigger-remote-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: 'bcgov/sso-requests-e2e'
+      - run: ls

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,10 +31,6 @@ jobs:
         with:
           repository: 'bcgov/sso-requests-e2e'
       - run: |
-          echo "localhost"
-          curl http://localhost:3000 || true
-          echo "1.0.0.0"
-          curl http://1.0.0.0:3000 || true
           echo "127.0.0.1"
           curl http://127.0.0.1:3000 || true
       # - name: E2E Smoke tests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,6 +31,7 @@ jobs:
         with:
           repository: 'bcgov/sso-requests-e2e'
       - run: |
+          sleep 300
           echo "127.0.0.1"
           curl http://127.0.0.1:3000 || true
       # - name: E2E Smoke tests

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,8 +15,11 @@ env:
   CYPRESS_guid: ${{ secrets.CYPRESS_GUID }}
   CYPRESS_loginproxy: ${{ secrets.CYPRESS_LOGINPROXY }}
   CYPRESS_siteminder: ${{ secrets.CYPRESS_SITEMINDER }}
+  CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CYPRESS_host: 'http://localhost:3000'
   CYPRESS_smoketest: true
+  CYPRESS_localtest: true
 
 jobs:
   smoke-test:
@@ -41,7 +44,7 @@ jobs:
         continue-on-error: false
         with:
           summary-title: 'E2E Smoke tests'
-          record: false
+          record: true
           wait-on: 'http://localhost:3000'
           wait-on-timeout: 180
           install-command: npm ci

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,7 @@ jobs:
           install-command: npm ci
           working-directory: testing
           spec: |
-            cypress/e2e/*
+            cypress/e2e/**/integration-*-*.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
       - run: ls

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -36,8 +36,6 @@ jobs:
         continue-on-error: false
         with:
           summary-title: 'E2E Smoke tests'
-          wait-on: localhost:3000
-          wait-on-timeout: 120
           record: true
           install-command: npm ci
           working-directory: testing

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -53,6 +53,7 @@ jobs:
           working-directory: testing
           spec: |
             cypress/e2e/**/prereq.cy.ts
+            cypress/e2e/**/integration-*-*.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,9 +10,21 @@ on:
     branches:
       - ssoteam-1572
 
+env:
+  CYPRESS_users: ${{ secrets.CYPRESS_USERS }}
+  CYPRESS_guid: ${{ secrets.CYPRESS_GUID }}
+  CYPRESS_loginproxy: ${{ secrets.CYPRESS_LOGINPROXY }}
+  CYPRESS_siteminder: ${{ secrets.CYPRESS_SITEMINDER }}
+  CYPRESS_host: localhost:3000
+
 jobs:
-  trigger-remote-workflow:
+  smoke-test:
     runs-on: ubuntu-latest
+    steps:
+  cypress:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
     steps:
       - uses: actions/checkout@v4
       - uses: isbang/compose-action@v1.5.1
@@ -21,4 +33,20 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'bcgov/sso-requests-e2e'
-      - run: ls
+      - name: E2E Smoke tests
+        uses: cypress-io/github-action@v6
+        id: smoke
+        continue-on-error: false
+        with:
+          summary-title: 'E2E Smoke tests'
+          wait-on: localhost:3000
+          wait-on-timeout: 120
+          record: true
+          install-command: npm ci
+          working-directory: testing
+          spec: |
+            cypress/e2e/smoke/smoke-*-*.cy.ts
+          browser: electron
+          ci-build-id: ${{ github.event.number }}
+      # - run: ls
+      # - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,14 +1,11 @@
 name: Run E2E tests
 
 on:
-  # pull_request_target:
-  #   types:
-  #     - opened
-  #     - edited
-  #     - synchronize
-  push:
-    branches:
-      - ssoteam-1572
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
 
 env:
   CYPRESS_users: ${{ secrets.CYPRESS_USERS }}
@@ -19,14 +16,14 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CYPRESS_host: 'http://localhost:3000'
   CYPRESS_smoketest: true
-  CYPRESS_localtest: 'true'
+  CYPRESS_localtest: true
   CYPRESS_BASE_URL: 'http://localhost:3000'
 
 jobs:
   smoke-test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false # https://github.com/cypress-io/github-action/issues/48
+      fail-fast: false
     steps:
       - uses: actions/checkout@v4
       - uses: isbang/compose-action@v1.5.1
@@ -36,10 +33,6 @@ jobs:
         with:
           repository: 'bcgov/sso-requests-e2e'
           ref: 'fix/prereqs'
-      # - run: |
-      #     sleep 300
-      #     echo "localhost"
-      #     curl http://localhost:3000 || true
       - name: E2E Smoke tests
         uses: cypress-io/github-action@v6
         id: smoke
@@ -58,4 +51,3 @@ jobs:
             cypress/e2e/**/integration-990-deleteAllIntegrations.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
-      - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -20,6 +20,7 @@ env:
   CYPRESS_host: 'http://localhost:3000'
   CYPRESS_smoketest: true
   CYPRESS_localtest: 'true'
+  CYPRESS_BASE_URL: 'http://localhost:3000'
 
 jobs:
   smoke-test:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,6 +35,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'bcgov/sso-requests-e2e'
+          ref: 'fix/prereqs'
       # - run: |
       #     sleep 300
       #     echo "localhost"
@@ -51,7 +52,7 @@ jobs:
           install-command: npm ci
           working-directory: testing
           spec: |
-            cypress/e2e/**/integration-010-*.cy.ts
+            cypress/e2e/**/prereq.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: isbang/compose-action@v1.5.1
         with:
-          compose-file: '.docker-compose.yml'
+          compose-file: './docker-compose.yml'
       # - uses: actions/checkout@v4
       #   with:
       #     repository: 'bcgov/sso-requests-e2e'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,4 @@
-name: Lint PR
+name: Run E2E tests
 
 on:
   # pull_request_target:
@@ -18,7 +18,7 @@ jobs:
       - uses: isbang/compose-action@v1.5.1
         with:
           compose-file: './docker-compose.yml'
-      # - uses: actions/checkout@v4
-      #   with:
-      #     repository: 'bcgov/sso-requests-e2e'
-      # - run: ls
+      - uses: actions/checkout@v4
+        with:
+          repository: 'bcgov/sso-requests-e2e'
+      - run: ls

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -15,7 +15,7 @@ env:
   CYPRESS_guid: ${{ secrets.CYPRESS_GUID }}
   CYPRESS_loginproxy: ${{ secrets.CYPRESS_LOGINPROXY }}
   CYPRESS_siteminder: ${{ secrets.CYPRESS_SITEMINDER }}
-  CYPRESS_host: 'http://127.0.0.1:3000'
+  CYPRESS_host: 'http://localhost:3000'
   CYPRESS_smoketest: true
 
 jobs:
@@ -33,8 +33,8 @@ jobs:
           repository: 'bcgov/sso-requests-e2e'
       # - run: |
       #     sleep 300
-      #     echo "127.0.0.1"
-      #     curl http://127.0.0.1:3000 || true
+      #     echo "localhost"
+      #     curl http://localhost:3000 || true
       - name: E2E Smoke tests
         uses: cypress-io/github-action@v6
         id: smoke
@@ -42,7 +42,7 @@ jobs:
         with:
           summary-title: 'E2E Smoke tests'
           record: false
-          wait-on: 'http://127.0.0.1:3000'
+          wait-on: 'http://localhost:3000'
           wait-on-timeout: 180
           install-command: npm ci
           working-directory: testing

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,7 +52,10 @@ jobs:
           install-command: npm ci
           working-directory: testing
           spec: |
-            cypress/e2e/**/integration-*-*.cy.ts
+            cypress/e2e/**/integration-010-createIntegration.cy.ts
+            cypress/e2e/**/integration-010-createIntegration.cy.ts
+            cypress/e2e/**/team-001-createTeam.cy.ts
+            cypress/e2e/**/team-900-deleteAllTeams.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,7 +14,11 @@ jobs:
   trigger-remote-workflow:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+      - uses: isbang/compose-action@v1.5.1
         with:
-          repository: 'bcgov/sso-requests-e2e'
-      - run: ls
+          compose-file: '.docker-compose.yml'
+      # - uses: actions/checkout@v4
+      #   with:
+      #     repository: 'bcgov/sso-requests-e2e'
+      # - run: ls

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -43,6 +43,7 @@ jobs:
           summary-title: 'E2E Smoke tests'
           record: false
           wait-on: 'http://127.0.0.1:3000'
+          wait-on-timeout: 180
           install-command: npm ci
           working-directory: testing
           spec: |

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -19,7 +19,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   CYPRESS_host: 'http://localhost:3000'
   CYPRESS_smoketest: true
-  CYPRESS_localtest: true
+  CYPRESS_localtest: 'true'
 
 jobs:
   smoke-test:
@@ -53,5 +53,4 @@ jobs:
             cypress/e2e/**/integration-010-*.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
-      - run: ls
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,6 +16,7 @@ env:
   CYPRESS_loginproxy: ${{ secrets.CYPRESS_LOGINPROXY }}
   CYPRESS_siteminder: ${{ secrets.CYPRESS_SITEMINDER }}
   CYPRESS_host: localhost:3000
+  CYPRESS_smoketest: true
 
 jobs:
   smoke-test:
@@ -45,7 +46,7 @@ jobs:
           install-command: npm ci
           working-directory: testing
           spec: |
-            cypress/e2e/smoke/smoke-*-*.cy.ts
+            cypress/e2e/*
           browser: electron
           ci-build-id: ${{ github.event.number }}
       - run: ls

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,7 +52,7 @@ jobs:
           install-command: npm ci
           working-directory: testing
           spec: |
-            cypress/e2e/**/prereq.cy.ts
+            cypress/e2e/**/01-prereq.cy.ts
             cypress/e2e/**/integration-*-*.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,10 +52,10 @@ jobs:
           install-command: npm ci
           working-directory: testing
           spec: |
-            cypress/e2e/**/integration-010-createIntegration.cy.ts
+            cypress/e2e/smoke/smoe-10-brokenlinks.cy.ts
             cypress/e2e/**/integration-010-createIntegration.cy.ts
             cypress/e2e/**/team-001-createTeam.cy.ts
-            cypress/e2e/**/team-900-deleteAllTeams.cy.ts
+            cypress/e2e/**/integration-990-deleteAllIntegrations.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
       - uses: actions/checkout@v4


### PR DESCRIPTION
Run a subset of the e2e test suite in our CI pipeline. I have altered a few tests on the fix/prereqs branch so that they can be run individually and still pass. We may need to add a new testsuite that is stateless to use in CI, but the current setup to run agains the docker compose and hit it with cypress is all setup now