### PR TITLE
chore: paths in action

### DIFF
--- a/.github/workflows/e2e-smoke-test.yaml
+++ b/.github/workflows/e2e-smoke-test.yaml
@@ -20,9 +20,6 @@ on:
       - dev
     types:
       - completed
-    paths:
-      - app/**
-      - lambda/**
 
 jobs:
   trigger-remote-workflow:

--- a/.github/workflows/e2e-smoke-test.yaml
+++ b/.github/workflows/e2e-smoke-test.yaml
@@ -20,6 +20,9 @@ on:
       - dev
     types:
       - completed
+    paths:
+      - app/**
+      - lambda/**
 
 jobs:
   trigger-remote-workflow:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -6,6 +6,9 @@ on:
       - opened
       - edited
       - synchronize
+    paths:
+      - app/**
+      - lambda/**
 
 env:
   CYPRESS_users: ${{ secrets.CYPRESS_USERS }}


### PR DESCRIPTION
- only run e2e workflows when the frontend or backend change