### PR TITLE
fix: disallow public service accounts

### DIFF
--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -146,11 +146,11 @@ function FormTemplate({ currentUser, request, alert }: Props) {
 
   const throttleUpdate = useCallback(
     throttle(
-      async (event: any) => {
+      async (data: Integration) => {
         if (isNew || isApplied) return;
         if (request) {
           setSaving(true);
-          const [, err] = await updateRequest({ ...event.formData, id: request.id });
+          const [, err] = await updateRequest({ ...data, id: request.id });
           if (!err) setSaveMessage(`Last saved at ${new Date().toLocaleString()}`);
           setSaving(false);
         }
@@ -206,7 +206,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
       window.location.hash = 'info-modal';
     }
 
-    throttleUpdate(e);
+    throttleUpdate(processed);
   };
 
   const loadTeams = async () => {

--- a/app/jest/form.test.tsx
+++ b/app/jest/form.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within, prettyDOM } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import FormTemplate from 'form-components/FormTemplate';
 import { updateRequest } from 'services/request';
 import { Integration } from 'interfaces/Request';
@@ -7,7 +7,6 @@ import { setUpRouter } from './utils/setup';
 import { errorMessages } from '../utils/constants';
 import { sampleRequest } from './samples/integrations';
 import { MAX_IDLE_SECONDS, MAX_LIFETIME_SECONDS } from '@app/utils/validate';
-import { JestAxe } from 'jest-axe';
 
 const formButtonText = ['Next', 'Save and Close'];
 
@@ -18,10 +17,7 @@ jest.mock('next/router', () => ({
 jest.mock('services/request', () => {
   return {
     createRequest: jest.fn(),
-    updateRequest: jest.fn(() => {
-      console.log('what the hell');
-      return Promise.resolve([{}, null]);
-    }),
+    updateRequest: jest.fn(() => Promise.resolve([{}, null])),
     getRequest: jest.fn(),
   };
 });

--- a/app/jest/form.test.tsx
+++ b/app/jest/form.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within, prettyDOM } from '@testing-library/react';
 import FormTemplate from 'form-components/FormTemplate';
 import { updateRequest } from 'services/request';
 import { Integration } from 'interfaces/Request';
@@ -7,6 +7,7 @@ import { setUpRouter } from './utils/setup';
 import { errorMessages } from '../utils/constants';
 import { sampleRequest } from './samples/integrations';
 import { MAX_IDLE_SECONDS, MAX_LIFETIME_SECONDS } from '@app/utils/validate';
+import { JestAxe } from 'jest-axe';
 
 const formButtonText = ['Next', 'Save and Close'];
 
@@ -17,7 +18,10 @@ jest.mock('next/router', () => ({
 jest.mock('services/request', () => {
   return {
     createRequest: jest.fn(),
-    updateRequest: jest.fn(() => Promise.resolve([{}, null])),
+    updateRequest: jest.fn(() => {
+      console.log('what the hell');
+      return Promise.resolve([{}, null]);
+    }),
     getRequest: jest.fn(),
   };
 });
@@ -83,6 +87,31 @@ describe('Form Template Saving and Navigation', () => {
     await waitFor(() => document.querySelector("svg[testid='rotating-lines-svg']"));
     // wait for spinner to change to checkmark
     await waitFor(() => document.querySelector("svg[icon='check']"));
+  });
+
+  it('Should call the update function with the most recent data', async () => {
+    setUpRender({ id: 1, status: 'draft', protocol: 'oidc', authType: 'browser-login' });
+    fireEvent.click(sandbox.basicInfoBox);
+    jest.clearAllMocks();
+
+    const THROTTLE_TIMEOUT = 2000;
+
+    const publicAccessRadioButton = document.querySelector('#root_publicAccess-Public') as HTMLElement;
+    const serviceAccountRadioButton = document.querySelector('input[value="service-account"]') as HTMLElement;
+
+    // Set access public, then switch to service account. API request should have the updated value as confidential.
+    fireEvent.click(publicAccessRadioButton);
+    fireEvent.click(serviceAccountRadioButton);
+
+    // Wait for the throttle to catch all api calls
+    await new Promise((res, rej) => {
+      setTimeout(() => {
+        res(true);
+      }, THROTTLE_TIMEOUT);
+    });
+
+    expect((updateRequest as jest.Mock).mock.calls[0].length).toBe(1);
+    expect((updateRequest as jest.Mock).mock.calls[0][0].publicAccess).toBe(false);
   });
 
   it('Should advance the form when clicking next', async () => {

--- a/app/jest/samples/integrations.ts
+++ b/app/jest/samples/integrations.ts
@@ -18,4 +18,5 @@ export const sampleRequest: Integration = {
   serviceType: 'gold',
   primaryEndUsers: ['livingInBC'],
   primaryEndUsersOther: '',
+  authType: 'browser-login',
 };

--- a/app/schemas/providers-gold.ts
+++ b/app/schemas/providers-gold.ts
@@ -160,7 +160,7 @@ export default function getSchema(integration: Integration, context: { isAdmin?:
 
   return {
     type: 'object',
-    customValidation: ['additionalRoleAttribute', 'clientId', 'devIdps'],
+    customValidation: ['additionalRoleAttribute', 'clientId', 'devIdps', 'authType'],
     headerText: 'Choose providers',
     stepText: 'Basic Info',
     properties,

--- a/app/utils/validate.ts
+++ b/app/utils/validate.ts
@@ -51,6 +51,8 @@ export const customValidate = (formData: any, errors: FormValidation, fields?: s
     devSessionMaxLifespan,
     testSessionMaxLifespan,
     prodSessionMaxLifespan,
+    authType,
+    publicAccess,
   } = formData;
 
   const sessionIdleTimeout = (value: number, key: string) => {
@@ -73,6 +75,11 @@ export const customValidate = (formData: any, errors: FormValidation, fields?: s
     projectName: () => {
       if (/^\d/.test(projectName)) {
         errors['projectName'].addError('Please have your project name start with a letter');
+      }
+    },
+    authType: () => {
+      if (authType !== 'browser-login' && publicAccess) {
+        errors['authType'].addError('Ensure your access is confidential when using a service account.');
       }
     },
     devSessionIdleTimeout: sessionIdleTimeout(devSessionIdleTimeout, 'devSessionIdleTimeout'),

--- a/lambda/__tests__/03.requests-by-users.test.ts
+++ b/lambda/__tests__/03.requests-by-users.test.ts
@@ -169,6 +169,25 @@ describe('create/manage integration by authenticated user', () => {
       expect(sendEmail).toHaveBeenCalled();
     });
 
+    it('Should not allow public service accounts', async () => {
+      createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
+      const integrationClone = { ...integration };
+
+      integrationClone.authType = 'service-account';
+      integrationClone.publicAccess = true;
+      let result = await updateIntegration(getUpdateIntegrationData({ integration: integrationClone }), true);
+      expect(result.status).toEqual(422);
+
+      integrationClone.authType = 'both';
+      result = await updateIntegration(getUpdateIntegrationData({ integration: integrationClone }), true);
+      expect(result.status).toEqual(422);
+
+      // Public is okay if browser-login auth type
+      integrationClone.authType = 'browser-login';
+      result = await updateIntegration(getUpdateIntegrationData({ integration: integrationClone }), true);
+      expect(result.status).toEqual(200);
+    });
+
     it('should allow to create a successful saml integration', async () => {
       createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
 

--- a/lambda/__tests__/07.emails-for-user-requests.test.ts
+++ b/lambda/__tests__/07.emails-for-user-requests.test.ts
@@ -141,6 +141,7 @@ describe('integration email updates for individual users', () => {
         projectName,
         authType: 'service-account',
         submitted: true,
+        publicAccess: false,
       });
       expect(integrationRes.status).toEqual(200);
       let integration = integrationRes.body;

--- a/lambda/__tests__/08.emails-for-team-requests.test.ts
+++ b/lambda/__tests__/08.emails-for-team-requests.test.ts
@@ -176,6 +176,7 @@ describe('integration email updates for teams', () => {
         teamId,
         authType: 'service-account',
         submitted: true,
+        publicAccess: false,
       });
       expect(integrationRes.status).toEqual(200);
       let integration = integrationRes.body;


### PR DESCRIPTION
This will cause an issue for clients who have triggered this bug previously. In production, there are only two clients who have done so (One is a test account of ours, the other is from a client).I think they can both be deleted (the client one has created another to replace it I believe, it is the same client who flagged this bug for us). Our form logic disables the public/confidential radios and the account type buttons once an integration is applied, so there is no good way to allow a self fix from the UI. If the client one cannot be deleted we will have to update the DB and keycloak client manually to allow it to be editable.