### PR TITLE
feat: restore integration

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,7 @@
 name: Run E2E tests
 
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,4 +1,4 @@
-name: Run E2E tests test
+name: Run E2E tests
 
 on:
   pull_request_target:
@@ -9,6 +9,7 @@ on:
     paths:
       - app/**
       - lambda/**
+      - docker-compose.yml
 
 env:
   CYPRESS_users: ${{ secrets.CYPRESS_USERS }}
@@ -23,7 +24,7 @@ env:
   CYPRESS_BASE_URL: 'http://localhost:3000'
 
 jobs:
-  ci-test:
+  smoke-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,17 +1,14 @@
 name: Run E2E tests test
 
 on:
-  # pull_request_target:
-  #   types:
-  #     - opened
-  #     - edited
-  #     - synchronize
-  #   paths:
-  #     - app/**
-  #     - lambda/**
-  push:
-    branches:
-      - ssoteam-1408
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+    paths:
+      - app/**
+      - lambda/**
 
 env:
   CYPRESS_users: ${{ secrets.CYPRESS_USERS }}
@@ -54,6 +51,3 @@ jobs:
             cypress/e2e/ci/*.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
-      - uses: actions/checkout@v4
-        with:
-          repository: 'bcgov/sso-requests'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -35,6 +35,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'bcgov/sso-requests-e2e'
+      - name: wait
+        run: sleep 180s
+        shell: bash
       - name: E2E Tests
         uses: cypress-io/github-action@v6
         id: smoke

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,14 +1,17 @@
-name: Run E2E tests
+name: Run E2E tests test
 
 on:
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - synchronize
-    paths:
-      - app/**
-      - lambda/**
+  # pull_request_target:
+  #   types:
+  #     - opened
+  #     - edited
+  #     - synchronize
+  #   paths:
+  #     - app/**
+  #     - lambda/**
+  push:
+    branches:
+      - ssoteam-1408
 
 env:
   CYPRESS_users: ${{ secrets.CYPRESS_USERS }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -10,6 +10,7 @@ on:
       - app/**
       - lambda/**
       - docker-compose.yml
+      - github/workflows/e2e.yaml
 
 env:
   CYPRESS_users: ${{ secrets.CYPRESS_USERS }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -30,6 +30,7 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
+      - run: cat docker-compose.yml
       - uses: isbang/compose-action@v1.5.1
         with:
           compose-file: './docker-compose.yml'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -23,7 +23,7 @@ env:
   CYPRESS_BASE_URL: 'http://localhost:3000'
 
 jobs:
-  smoke-test:
+  ci-test:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -38,9 +38,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'bcgov/sso-requests-e2e'
-      - name: wait
-        run: sleep 180s
-        shell: bash
       - name: E2E Tests
         uses: cypress-io/github-action@v6
         id: smoke
@@ -58,3 +55,5 @@ jobs:
           browser: electron
           ci-build-id: ${{ github.event.number }}
       - uses: actions/checkout@v4
+        with:
+          repository: 'bcgov/sso-requests'

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -57,3 +57,4 @@ jobs:
             cypress/e2e/ci/*.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
+      - uses: actions/checkout@v4

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,7 +31,6 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
-      - run: cat docker-compose.yml
       - uses: isbang/compose-action@v1.5.1
         with:
           compose-file: './docker-compose.yml'

--- a/app/components/CenteredModal.tsx
+++ b/app/components/CenteredModal.tsx
@@ -137,19 +137,21 @@ const CenteredModal = ({
                 Cancel
               </Button>
             )}
-            <Button
-              data-testid={dataTestId}
-              onClick={handleConfirm}
-              variant={confirmButtonVariant}
-              type="button"
-              className="text-center"
-            >
-              {loading ? (
-                <SpinnerGrid color="#FFF" height={18} width={50} wrapperClass="d-block" visible={loading} />
-              ) : (
-                confirmText
-              )}
-            </Button>
+            {showConfirm && (
+              <Button
+                data-testid={dataTestId}
+                onClick={handleConfirm}
+                variant={confirmButtonVariant}
+                type="button"
+                className="text-center"
+              >
+                {loading ? (
+                  <SpinnerGrid color="#FFF" height={18} width={50} wrapperClass="d-block" visible={loading} />
+                ) : (
+                  confirmText
+                )}
+              </Button>
+            )}
           </ButtonContainer>
         )}
       </Modal.Content>

--- a/app/jest/ssoDashboard.test.tsx
+++ b/app/jest/ssoDashboard.test.tsx
@@ -9,6 +9,8 @@ const sampleSession = {
   isAdmin: true,
 };
 
+const MOCK_EMAIL = 'some@email.com';
+
 function MockRequestAllResult() {
   let requestAllResult: Integration[] = [];
   for (let i = 1; i <= 6; i++) {
@@ -44,6 +46,12 @@ jest.mock('services/request', () => {
 jest.mock('services/event', () => {
   return {
     getEvents: jest.fn(() => Promise.resolve([[], null])),
+  };
+});
+
+jest.mock('services/user', () => {
+  return {
+    getIdirUsersByEmail: jest.fn(() => Promise.resolve([[{ mail: MOCK_EMAIL, id: 1 }]])),
   };
 });
 
@@ -170,6 +178,12 @@ describe('SSO Dashboard', () => {
 
     //click on restore icon
     const restoreButton = screen.getAllByRole('button', { name: 'Restore at Keycloak' });
+    const userSearch = document.querySelector('#restoration-email-select input') as Element;
+    fireEvent.change(userSearch, { target: { value: MOCK_EMAIL } });
+    await waitFor(() => {
+      expect(screen.getByDisplayValue(MOCK_EMAIL)).toBeInTheDocument();
+      screen.getByText(MOCK_EMAIL).click();
+    });
     fireEvent.click(restoreButton[0]);
     await waitFor(() => {
       expect(screen.getByTitle('Confirm Restoration')).toBeInTheDocument();

--- a/app/pages/admin-dashboard.tsx
+++ b/app/pages/admin-dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, ReactNode } from 'react';
 import { useRouter } from 'next/router';
 import startCase from 'lodash.startcase';
 import { faTrash, faEdit, faEye, faTrashRestoreAlt } from '@fortawesome/free-solid-svg-icons';
@@ -13,7 +13,12 @@ import { formatFilters, hasAnyPendingStatus } from 'utils/helpers';
 import AdminTabs, { TabKey } from 'page-partials/admin-dashboard/AdminTabs';
 import { workflowStatusOptions } from 'metadata/options';
 import VerticalLayout from 'page-partials/admin-dashboard/VerticalLayout';
-import { deleteServiceAccount, restoreServiceAccount } from '@app/services/team';
+import { deleteServiceAccount, getAllowedTeam, restoreServiceAccount } from '@app/services/team';
+import AsyncSelect from 'react-select/async';
+import { SingleValue } from 'react-select';
+import debounce from 'lodash.debounce';
+import { getIdirUsersByEmail } from '@app/services/user';
+import styled from 'styled-components';
 
 const idpOptions = [
   { value: 'idir', label: 'IDIR' },
@@ -38,6 +43,131 @@ const pageLimits = [5, 10, 15, 30, 50, 100];
 function ActionsHeader() {
   return <span style={{ marginLeft: '40%' }}>Actions</span>;
 }
+
+const RequestRestorationContainer = styled.div`
+  label {
+    margin-bottom: 0.5em;
+  }
+  .error-text {
+    margin-top: 0.5em;
+    color: red;
+  }
+`;
+
+const throttledIdirSearch = debounce(
+  (email, cb) => {
+    if (email.length <= 2) {
+      cb([]);
+      return;
+    }
+    getIdirUsersByEmail(email).then(([data]) => cb(data?.map((user) => ({ value: user.id, label: user.mail })) || []));
+  },
+  300,
+  { trailing: true },
+);
+
+/**
+ * Component to control restoration. Rules are:
+ *  1. If the integration is team owned and the team still exists, restore it.
+ *  2. If the integration is team owned and the team does not exist, require an email.
+ *  3. If the integration is not team owned, require an email.
+ *  4. If the integration for a team service account, and the team is deleted, do not allow restoration.
+ */
+const RestoreModalContent = ({
+  selectedIntegration,
+  loadData,
+}: {
+  selectedIntegration?: Integration;
+  loadData: () => Promise<void>;
+}) => {
+  const [teamExists, setTeamExists] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [selectedEmail, setSelectedEmail] = useState<string>('');
+  const [error, setError] = useState('');
+
+  const checkTeamExistence = async () => {
+    setLoading(true);
+    const [teamExists, _err] = await getAllowedTeam(String(selectedIntegration!.teamId));
+    setTeamExists(!!teamExists);
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    setError('');
+    setSelectedEmail('');
+    if (selectedIntegration?.usesTeam) {
+      checkTeamExistence();
+    }
+  }, [selectedIntegration?.id]);
+
+  useEffect(() => {
+    setError('');
+  }, [selectedEmail]);
+
+  const confirmRestore = async () => {
+    const emailRequired = !(selectedIntegration?.usesTeam && teamExists);
+
+    if (emailRequired && !selectedEmail) {
+      setError('Please select an email address to restore the integration to.');
+      return;
+    }
+
+    if (selectedIntegration?.apiServiceAccount) {
+      await restoreServiceAccount(Number(selectedIntegration?.teamId), selectedIntegration?.id);
+    } else {
+      await restoreRequest(selectedIntegration?.id, selectedEmail);
+    }
+    await loadData();
+    handleClose();
+    window.location.hash = '#';
+  };
+
+  const handleClose = () => {
+    setSelectedEmail('');
+    setError('');
+  };
+
+  if (!selectedIntegration) return null;
+
+  let content: string | ReactNode = '';
+  if (loading) {
+    content = 'Checking if the team exists...';
+  } else if (selectedIntegration.usesTeam && teamExists) {
+    content = 'You are about to restore this integration.';
+  } else if (selectedIntegration.apiServiceAccount && !teamExists) {
+    content = 'Cannot restore this team account, team does not exist.';
+  } else {
+    content = (
+      <RequestRestorationContainer>
+        <label htmlFor="restoration-email-select">Select an email to assign the integration to.</label>
+        <AsyncSelect
+          loadOptions={throttledIdirSearch}
+          value={{ value: selectedEmail, label: selectedEmail }}
+          onChange={(option: SingleValue<{ value: string; label: string }>) => setSelectedEmail(option?.label || '')}
+          noOptionsMessage={() => 'Start typing email...'}
+          maxMenuHeight={120}
+          placeholder={'Enter email address'}
+          id="restoration-email-select"
+        />
+        {error && <p className="error-text">Select an email address</p>}
+      </RequestRestorationContainer>
+    );
+  }
+
+  return (
+    <CenteredModal
+      id="restore-modal"
+      data-testid="modal-restore-integration"
+      content={content}
+      onConfirm={confirmRestore}
+      confirmText="Restore"
+      title="Confirm Restoration"
+      skipCloseOnConfirm
+      showConfirm={!(selectedIntegration.apiServiceAccount && !teamExists)}
+      onClose={handleClose}
+    />
+  );
+};
 
 export default function AdminDashboard({ session }: PageProps) {
   const router = useRouter();
@@ -146,7 +276,10 @@ export default function AdminDashboard({ session }: PageProps) {
   const handleRestore = async (request: Integration) => {
     if (!request.id || !canRestore(request)) return;
     setSelectedId(request.id);
-    window.location.hash = 'restore-modal';
+    window.location.hash = '';
+    process.nextTick(() => {
+      window.location.hash = 'restore-modal';
+    });
   };
 
   const confirmDelete = async () => {
@@ -154,15 +287,6 @@ export default function AdminDashboard({ session }: PageProps) {
     selectedRequest?.apiServiceAccount
       ? await deleteServiceAccount(selectedRequest?.teamId as number, selectedId)
       : await deleteRequest(selectedId);
-    await getData();
-    window.location.hash = '#';
-  };
-
-  const confirmRestore = async () => {
-    if (!canRestore) return;
-    selectedRequest?.apiServiceAccount
-      ? await restoreServiceAccount(selectedRequest?.teamId as number, selectedId)
-      : await restoreRequest(selectedId);
     await getData();
     window.location.hash = '#';
   };
@@ -331,14 +455,7 @@ export default function AdminDashboard({ session }: PageProps) {
         confirmText="Delete"
         title="Confirm Deletion"
       />
-      <CenteredModal
-        id="restore-modal"
-        data-testid="modal-restore-integration"
-        content="You are about to restore this integration."
-        onConfirm={confirmRestore}
-        confirmText="Restore"
-        title="Confirm Restoration"
-      />
+      <RestoreModalContent selectedIntegration={selectedRequest} loadData={loadData} />
     </>
   );
 }

--- a/app/services/request.ts
+++ b/app/services/request.ts
@@ -58,9 +58,12 @@ export const resubmitRequest = async (requestId: number): Promise<[Integration, 
   }
 };
 
-export const restoreRequest = async (requestId?: number): Promise<[Integration, null] | [null, AxiosError]> => {
+export const restoreRequest = async (
+  requestId?: number,
+  email?: string,
+): Promise<[Integration, null] | [null, AxiosError]> => {
   try {
-    const result: Integration = await instance.get(`requests/${requestId}/restore`).then((res) => res.data);
+    const result: Integration = await instance.post(`requests/${requestId}/restore`, { email }).then((res) => res.data);
     return [processRequest(result), null];
   } catch (err: any) {
     return handleAxiosError(err);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
 
   dev-keycloak:
     container_name: dev-keycloak
-    image: ghcr.io/bcgov/sso:dev
+    image: ghcr.io/bcgov/sso:7.6.39-build.1
     depends_on:
       - sso-db
     ports:
@@ -113,7 +113,7 @@ services:
 
   test-keycloak:
     container_name: test-keycloak
-    image: ghcr.io/bcgov/sso:dev
+    image: ghcr.io/bcgov/sso:7.6.39-build.1
     depends_on:
       - sso-db
     ports:
@@ -135,7 +135,7 @@ services:
 
   prod-keycloak:
     container_name: prod-keycloak
-    image: ghcr.io/bcgov/sso:dev
+    image: ghcr.io/bcgov/sso:7.6.39-build.1
     depends_on:
       - sso-db
     ports:

--- a/lambda/__tests__/03.requests-by-users.test.ts
+++ b/lambda/__tests__/03.requests-by-users.test.ts
@@ -378,13 +378,17 @@ describe('Restoration User Assignment', () => {
 
   beforeAll(async () => {
     jest.clearAllMocks();
-    createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
   });
 
   afterEach(async () => {
     await cleanUpDatabaseTables();
   });
 
+  /**
+   * Setup a created and deleted integration to test restoration.
+   * @param withTeam Set true to make a team owned integration
+   * @returns
+   */
   const setupIntegrationForRestore = async (withTeam: boolean) => {
     createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01, ['sso-admin']);
     let team: any;

--- a/lambda/__tests__/helpers/modules/integrations.ts
+++ b/lambda/__tests__/helpers/modules/integrations.ts
@@ -54,8 +54,8 @@ export const deleteIntegration = async (integrationId: number) => {
   return await supertest(app).del(`${APP_BASE_PATH}/requests?id=${integrationId}`);
 };
 
-export const restoreIntegration = async (integrationId: number) => {
-  return await supertest(app).get(`${APP_BASE_PATH}/requests/${integrationId}/restore`);
+export const restoreIntegration = async (integrationId: number, email?: string) => {
+  return await supertest(app).post(`${APP_BASE_PATH}/requests/${integrationId}/restore`).send({ email });
 };
 
 export const fetchMetrics = async (integrationId: number, fromDate: string, toDate: string, env: string) => {

--- a/lambda/app/src/bceid-webservice-proxy/idir.ts
+++ b/lambda/app/src/bceid-webservice-proxy/idir.ts
@@ -61,6 +61,16 @@ export const fuzzySearchIdirEmail = async (email: string) => {
   return callAzureGraphApi(url).then((res) => res.value?.map((value) => ({ mail: value.mail, id: value.id })));
 };
 
+export const validateIdirEmail = async (email: string) => {
+  const url = `${MS_GRAPH_URL}/v1.0/users/${email}`;
+  try {
+    const response = await callAzureGraphApi(url);
+    return { given_name: response.givenName, family_name: response.surname };
+  } catch (error) {
+    return false;
+  }
+};
+
 /**Search IDIR users using the bceid service by a general field and value */
 export const searchIdirUsers = async (bearerToken: string, { field, search }: { field: string; search: string }) => {
   const results = await axios

--- a/lambda/app/src/routes.ts
+++ b/lambda/app/src/routes.ts
@@ -279,14 +279,18 @@ export const setRoutes = (app: any) => {
     }
   });
 
-  app.get(`/requests/:id/restore`, async (req, res) => {
+  app.post(`/requests/:id/restore`, async (req, res) => {
     try {
       assertSessionRole(req.session, 'sso-admin');
       const { id } = req.params || {};
+      let { email } = req.body || {};
+      if (typeof email === 'string') {
+        email = email.toLowerCase();
+      }
       if (!id) {
         throw Error('integration ID not found');
       }
-      const result = await restoreRequest(req.session as Session, Number(id));
+      const result = await restoreRequest(req.session as Session, Number(id), email);
       res.status(200).json(result);
     } catch (err) {
       handleError(res, err);


### PR DESCRIPTION
Update the restore logic to allow admins to change ownership to a new idir email. This will be asked for unless the integration is owned by an existing team. I changed the e2e test to use `pull_request` trigger instead of `pull_request_target` so that a pr can update the test dependencies, otherwise it is using the target branch. For this run both will trigger but once merged it will just be the new one. The previous is failing because of an incorrect keycloak tag.