### PR TITLE
feat: client error handling update

### DIFF
--- a/app/components/ActionButtons.tsx
+++ b/app/components/ActionButtons.tsx
@@ -79,9 +79,9 @@ export default function Actionbuttons({
     const canDelete = !['pr', 'planned', 'submitted'].includes(request?.status || '');
     if (!canDelete) return;
 
-    await deleteRequest(request.id);
+    const [_result, error] = await deleteRequest(request.id);
     window.location.hash = '#';
-    if (onDelete) onDelete(request);
+    if (onDelete) onDelete(request, error);
   };
 
   return (

--- a/app/components/InstallationPanel.tsx
+++ b/app/components/InstallationPanel.tsx
@@ -54,27 +54,30 @@ const InstallationPanel = ({ integration, alert }: Props) => {
 
   const handleInstallationClick = async (environment: Environment) => {
     setLoading(true);
-    const [data] = await getInstallation(integration.id as number, environment);
+    const [data, error] = await getInstallation(integration.id as number, environment);
     setLoading(false);
+    if (error) {
+      alert.show({
+        variant: 'danger',
+        content: 'Failed to download installation',
+      });
+      return null;
+    }
     return data;
   };
 
   const handleCopyClick = async (env: Environment) => {
     const inst = await handleInstallationClick(env);
-    copyTextToClipboard(prettyJSON(inst));
-    const variant = inst ? 'success' : 'danger';
-    const content = inst ? 'Installation copied to clipboard' : 'Failed to download installation';
-    alert.show({
-      variant,
-      fadeOut: 10000,
-      closable: true,
-      content,
-    });
+    if (inst) {
+      copyTextToClipboard(prettyJSON(inst));
+    }
   };
 
   const handleDownloadClick = async (env: Environment) => {
     const inst = await handleInstallationClick(env);
-    downloadText(prettyJSON(inst), `${integration.projectName}-installation-${env}.json`);
+    if (inst) {
+      downloadText(prettyJSON(inst), `${integration.projectName}-installation-${env}.json`);
+    }
   };
 
   if (loading)

--- a/app/components/TableNew.tsx
+++ b/app/components/TableNew.tsx
@@ -424,7 +424,7 @@ function Table({
                     >
                       {row.cells.map((cell: Cell) => {
                         return (
-                          <td {...cell.getCellProps()} key={cell.value}>
+                          <td {...cell.getCellProps()} key={cell.getCellProps().key}>
                             {cell.render('Cell')}
                           </td>
                         );

--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -289,7 +289,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
             variant: 'danger',
             fadeOut: 5000,
             closable: true,
-            content: err,
+            content: 'Failed to submit request. Please try again.',
           });
         }
 
@@ -329,7 +329,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
           variant: 'danger',
           fadeOut: 10000,
           closable: true,
-          content: parseError(err),
+          content: 'Failed to submit request. Please try again.',
         });
       } else {
         alert.show({

--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -14,7 +14,6 @@ import FieldTemplate from 'form-components/FieldTemplate';
 import ArrayFieldTemplate from 'form-components/ArrayFieldTemplate';
 import CenteredModal from 'components/CenteredModal';
 import { validateForm, customValidate } from 'utils/validate';
-import { parseError } from 'utils/helpers';
 import {
   checkBceidBoth,
   checkBceidGroup,

--- a/app/form-components/team-form/CreateTeamForm.tsx
+++ b/app/form-components/team-form/CreateTeamForm.tsx
@@ -37,13 +37,17 @@ function CreateTeamForm({ onSubmit, alert }: Props) {
   const [members, setMembers] = useState<User[]>([emptyUser]);
   const [teamName, setTeamName] = useState('');
   const [loading, setLoading] = useState(false);
-  const [errors, setErrors] = useState<Errors>();
+  const [errors, setErrors] = useState<Errors | null>(null);
 
   const handleNameChange = (e: any) => {
     setTeamName(e.target.value);
   };
 
   const handleCancel = () => {
+    setMembers([emptyUser]);
+    setTeamName('');
+    setLoading(false);
+    setErrors(null);
     window.location.hash = '#';
   };
 
@@ -60,7 +64,7 @@ function CreateTeamForm({ onSubmit, alert }: Props) {
         variant: 'danger',
         fadeOut: 10000,
         closable: true,
-        content: err,
+        content: 'Failed to create team. Please try again.',
       });
     } else {
       alert.show({
@@ -74,6 +78,7 @@ function CreateTeamForm({ onSubmit, alert }: Props) {
     setMembers([emptyUser]);
     setTeamName('');
     setLoading(false);
+    setErrors(null);
     window.location.hash = '#';
   };
 

--- a/app/form-components/team-form/TeamMembersForm.tsx
+++ b/app/form-components/team-form/TeamMembersForm.tsx
@@ -55,6 +55,7 @@ const MemberContainer = styled(Container)`
   .email-select > .select-inner__control {
     padding: 0.13em 0;
     border: 2px solid #606060;
+    visibility: inherit;
 
     &:focus-within {
       outline: 4px solid #3b99fc !important;

--- a/app/jest/my-dashboard/my-projects/assignServiceAccountsToRoles.test.tsx
+++ b/app/jest/my-dashboard/my-projects/assignServiceAccountsToRoles.test.tsx
@@ -79,6 +79,8 @@ describe('assign service accounts to roles', () => {
     });
 
     // step: 3 Check the selected value
-    expect(getByTestId('assign-svc-acct-to-role-select')).toHaveTextContent(listClientRolesResponse);
+    await waitFor(() => {
+      expect(getByTestId('assign-svc-acct-to-role-select')).toHaveTextContent(listClientRolesResponse);
+    });
   });
 });

--- a/app/jest/my-dashboard/my-projects/assignUsersToRoles.test.tsx
+++ b/app/jest/my-dashboard/my-projects/assignUsersToRoles.test.tsx
@@ -180,6 +180,10 @@ describe('assign user to roles tab', () => {
     fireEvent.change(searchUserInput, { target: { value: 'sample_user' } });
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
 
+    await waitFor(() => {
+      screen.getByRole('button', { name: 'Search in IDIM Web Service Lookup' });
+    });
+
     fireEvent.click(screen.getByRole('button', { name: 'Search in IDIM Web Service Lookup' }));
     await waitFor(() => {
       expect(screen.getByTitle('IDIM Web Service Lookup')).toBeInTheDocument();

--- a/app/page-partials/my-dashboard/IntegrationInfoTabs/MetricsPanel.tsx
+++ b/app/page-partials/my-dashboard/IntegrationInfoTabs/MetricsPanel.tsx
@@ -1,14 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { EventCountMetric, Integration } from 'interfaces/Request';
-import { withTopAlert } from 'layout/TopAlert';
+import { TopAlert, withTopAlert } from 'layout/TopAlert';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Tabs, Tab } from '@bcgov-sso/common-react-components';
 import startCase from 'lodash.startcase';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Text, Legend } from 'recharts';
 import { getMetrics } from '@app/services/grafana';
 import throttle from 'lodash.throttle';
-import moment from 'moment';
 import DateTimePicker from '@app/components/DateTimePicker';
 import { InfoMessage } from '@app/components/MessageBox';
 import { Link } from '@button-inc/bcgov-theme';
@@ -54,6 +53,7 @@ const StyledHr = styled.hr`
 
 interface Props {
   integration: Integration;
+  alert: TopAlert;
 }
 
 const getFormattedDateString = (d: Date) => {
@@ -61,7 +61,7 @@ const getFormattedDateString = (d: Date) => {
 };
 
 const metricsStartDate = 'December 01, 2023';
-const MetricsPanel = ({ integration }: Props) => {
+const MetricsPanel = ({ integration, alert }: Props) => {
   const [environment, setEnvironment] = useState('dev');
   const environments = integration?.environments || [];
   const [metrics, setMetrics] = useState<EventCountMetric[]>([]);
@@ -85,9 +85,11 @@ const MetricsPanel = ({ integration }: Props) => {
   const fetchMetrics = useCallback(
     throttle(async (fromDate: string, toDate: string, environment: string) => {
       const [metricsData, err] = await getMetrics(integration?.id as number, environment, fromDate, toDate);
-
-      if (err || metricsData.length === 0) {
-        setMetrics([]);
+      if (err) {
+        alert.show({
+          variant: 'danger',
+          content: 'Failed to fetch metrics',
+        });
       } else {
         setMetrics(metricsData);
       }

--- a/app/page-partials/my-dashboard/IntegrationList.tsx
+++ b/app/page-partials/my-dashboard/IntegrationList.tsx
@@ -105,7 +105,7 @@ interface Props {
   alert: TopAlert;
 }
 
-function IntegrationList({ setIntegration, setIntegrationCount, alert }: Props) {
+function IntegrationList({ setIntegration, setIntegrationCount, alert }: Readonly<Props>) {
   const router = useRouter();
   let { integr } = router.query;
 

--- a/app/page-partials/my-dashboard/IntegrationList.tsx
+++ b/app/page-partials/my-dashboard/IntegrationList.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useEffect, Dispatch, SetStateAction } from 'react';
+import React, { useState, useEffect } from 'react';
 import Link from '@button-inc/bcgov-theme/Link';
 import { Integration } from 'interfaces/Request';
 import padStart from 'lodash.padstart';
@@ -17,6 +17,8 @@ import { hasAnyPendingStatus } from 'utils/helpers';
 import { authTypeDisplay } from 'metadata/display';
 import { SystemUnavailableMessage, NoEntitiesMessage } from './Messages';
 import { formatWikiURL } from 'utils/constants';
+import { AxiosError } from 'axios';
+import { TopAlert, withTopAlert } from '@app/layout/TopAlert';
 
 const RightFloatButtons = styled.tr`
   float: right;
@@ -100,14 +102,15 @@ const NewEntityButton = ({
 interface Props {
   setIntegration: Function;
   setIntegrationCount: (integrations: number) => void;
+  alert: TopAlert;
 }
 
-export default function IntegrationList({ setIntegration, setIntegrationCount }: Props) {
+function IntegrationList({ setIntegration, setIntegrationCount, alert }: Props) {
   const router = useRouter();
   let { integr } = router.query;
 
   const [loading, setLoading] = useState<boolean>(true);
-  const [hasError, setHasError] = useState<boolean>(false);
+  const [hasIntegrationLoadError, setHasIntegrationLoadError] = useState<boolean>(false);
   const [integrations, setIntegrations] = useState<Integration[]>([]);
   const [activeIntegrationId, setActiveIntegrationId] = useState<number | undefined>(
     (integr && Number(integr)) || undefined,
@@ -135,7 +138,7 @@ export default function IntegrationList({ setIntegration, setIntegrationCount }:
   const loadIntegrations = async () => {
     setLoading(true);
     const [integrations, err] = await getRequests();
-    setHasError(!!err);
+    setHasIntegrationLoadError(!!err);
     updateIntegrations(integrations || []);
     setLoading(false);
   };
@@ -175,7 +178,7 @@ export default function IntegrationList({ setIntegration, setIntegrationCount }:
   };
 
   const getTableContents = () => {
-    if (hasError) return <SystemUnavailableMessage />;
+    if (hasIntegrationLoadError) return <SystemUnavailableMessage />;
 
     if (!integrations || integrations.length === 0) return <NoEntitiesMessage message="No Requests Submitted" />;
 
@@ -221,8 +224,15 @@ export default function IntegrationList({ setIntegration, setIntegrationCount }:
                 <RightFloatButtons>
                   <ActionButtons
                     request={integration}
-                    onDelete={() => {
-                      loadIntegrations();
+                    onDelete={(_: any, error: AxiosError | null) => {
+                      if (error) {
+                        alert.show({
+                          variant: 'danger',
+                          content: `Failed to delete integration ${integration.projectName}.`,
+                        });
+                      } else {
+                        loadIntegrations();
+                      }
                     }}
                     defaultActiveColor="#fff"
                     delIconStyle={{ marginLeft: '7px' }}
@@ -253,3 +263,5 @@ export default function IntegrationList({ setIntegration, setIntegrationCount }:
     </>
   );
 }
+
+export default withTopAlert(IntegrationList);

--- a/app/page-partials/my-dashboard/Messages.tsx
+++ b/app/page-partials/my-dashboard/Messages.tsx
@@ -35,3 +35,10 @@ export const NoEntitiesMessage = ({ message }: { message: string }) => (
     &nbsp; {message}
   </NoProjects>
 );
+
+export const FailureMessage = ({ message }: { message: string }) => (
+  <NotAvailable>
+    <FontAwesomeIcon icon={faExclamationCircle} title="Error" />
+    &nbsp; {message}
+  </NotAvailable>
+);

--- a/app/page-partials/my-dashboard/RoleManagement/CreateRoleContent.tsx
+++ b/app/page-partials/my-dashboard/RoleManagement/CreateRoleContent.tsx
@@ -79,6 +79,11 @@ function CreateRoleContent({ integrationId, environments = ['dev'] }: Props, ref
       }
 
       const [results, error] = await bulkCreateRole({ integrationId, roles: _roles });
+
+      if (error) {
+        return [true, false];
+      }
+
       const _failures: Result = {};
       const _duplicates: Result = {};
       let hasError = false;

--- a/app/page-partials/my-dashboard/RoleManagement/RoleEnvironment.tsx
+++ b/app/page-partials/my-dashboard/RoleManagement/RoleEnvironment.tsx
@@ -235,8 +235,6 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
     if (err || !data) {
       alert.show({
         variant: 'danger',
-        fadeOut: 5000,
-        closable: true,
         content: 'Failed to fetch roles.',
       });
     }
@@ -277,8 +275,6 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
     if (err) {
       return alert.show({
         variant: 'danger',
-        fadeOut: 5000,
-        closable: true,
         content: 'Failed to fetch users.',
       });
     }
@@ -628,8 +624,6 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
           if (error) {
             alert.show({
               variant: 'danger',
-              fadeOut: 5000,
-              closable: true,
               content: `Failed to delete role ${roleName}. Please try again.`,
             });
           }
@@ -661,8 +655,6 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
           if (err) {
             alert.show({
               variant: 'danger',
-              fadeOut: 5000,
-              closable: true,
               content: err,
             });
           }
@@ -694,8 +686,6 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
           if (err) {
             alert.show({
               variant: 'danger',
-              fadeOut: 5000,
-              closable: true,
               content: err,
             });
           }

--- a/app/page-partials/my-dashboard/RoleManagement/RoleEnvironment.tsx
+++ b/app/page-partials/my-dashboard/RoleManagement/RoleEnvironment.tsx
@@ -1,8 +1,7 @@
 import React, { MouseEvent, useEffect, useState, useRef, useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faTrash, faExclamationTriangle, faMinusCircle } from '@fortawesome/free-solid-svg-icons';
-import { faExclamationCircle, faEye, faDownload, faLock } from '@fortawesome/free-solid-svg-icons';
+import { faTrash, faExclamationTriangle, faMinusCircle, faEye } from '@fortawesome/free-solid-svg-icons';
 import Select, { MultiValue, ActionMeta } from 'react-select';
 import throttle from 'lodash.throttle';
 import get from 'lodash.get';
@@ -147,6 +146,7 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
   const [canCreateOrDeleteRole, setCanCreateOrDeleteRole] = useState(false);
   const [rightPanelTab, setRightPanelTab] = useState<string>('');
   const [serviceAccountIntMap, setServiceAccountIntMap] = useState<SvcAcctUserIntegrationMapType[]>([]);
+  const [compositeRoleError, setCompositeRoleError] = useState(false);
 
   const populateTabs = () => {
     if (integration.authType === 'service-account') {
@@ -166,7 +166,8 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
       async (newValues: Option[]) => {
         if (!selectedRole) return;
 
-        await setSaving(true);
+        setSaving(true);
+        setCompositeRoleError(false);
         const [, err] = await setCompositeClientRoles({
           environment,
           integrationId: integration.id as number,
@@ -174,9 +175,16 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
           compositeRoleNames: newValues.map((v) => v.value) as string[],
         });
 
+        if (err) {
+          setSavingMessage('Failed to save changes.');
+          setCompositeRoleError(true);
+          setSaving(false);
+          return false;
+        }
+
         if (!err) setSavingMessage(`Last saved at ${new Date().toLocaleString()}`);
         await setSaving(false);
-        await fetchRoles();
+        return true;
       },
       2000,
       { trailing: true },
@@ -229,7 +237,7 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
         variant: 'danger',
         fadeOut: 5000,
         closable: true,
-        content: err?.message || 'failed to fetch roles',
+        content: 'Failed to fetch roles.',
       });
     }
 
@@ -265,6 +273,15 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
       first: _first,
       max: maxUser,
     });
+
+    if (err) {
+      return alert.show({
+        variant: 'danger',
+        fadeOut: 5000,
+        closable: true,
+        content: 'Failed to fetch users.',
+      });
+    }
 
     let _data = data || [];
 
@@ -305,7 +322,7 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
         variant: 'danger',
         fadeOut: 5000,
         closable: true,
-        content: err || 'failed to fetch composite roles',
+        content: 'Failed to fetch composite roles.',
       });
       return;
     }
@@ -493,13 +510,18 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
             isMulti={true}
             placeholder="Select..."
             noOptionsMessage={() => 'No roles'}
-            onChange={(newValues) => {
-              setCompositeRoles(newValues as Option[]);
-              throttleCompositeRoleUpdate(newValues as Option[]);
+            onChange={async (newValues) => {
+              await throttleCompositeRoleUpdate(newValues as Option[])?.then(
+                (updateSucceeded) => updateSucceeded && setCompositeRoles(newValues as Option[]),
+              );
             }}
             isDisabled={!canCreateOrDeleteRole}
           />
-          <LastSavedMessage saving={saving} content={savingMessage} />
+          <LastSavedMessage
+            saving={saving}
+            content={savingMessage}
+            variant={compositeRoleError ? 'error' : 'success'}
+          />
         </>
       );
     }
@@ -597,11 +619,20 @@ const RoleEnvironment = ({ environment, integration, alert }: Props) => {
         title="Delete Role"
         icon={faExclamationTriangle}
         onConfirm={async (contentRef: any, roleName: string) => {
-          await deleteRole({
+          const [_, error] = await deleteRole({
             environment,
             integrationId: integration.id as number,
             roleName,
           });
+
+          if (error) {
+            alert.show({
+              variant: 'danger',
+              fadeOut: 5000,
+              closable: true,
+              content: `Failed to delete role ${roleName}. Please try again.`,
+            });
+          }
 
           await reset();
         }}

--- a/app/page-partials/my-dashboard/ServiceAccountRoles.tsx
+++ b/app/page-partials/my-dashboard/ServiceAccountRoles.tsx
@@ -65,21 +65,31 @@ const ServiceAccountRoles = ({ selectedRequest, alert }: Props) => {
   const [userRoles, setUserRoles] = useState<string[]>([]);
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
   const [environment, setEnvironment] = useState('dev');
+  const [userAssignmentError, setUserAssignmentError] = useState(false);
 
   const environments = selectedRequest?.environments || [];
 
   const throttleUpdate = useCallback(
     throttle(
       async (roleNames: string[]) => {
-        await setSaving(true);
+        setSaving(true);
+        setSavingMessage('Assigning role...');
+        setUserAssignmentError(false);
         const [, err] = await manageUserRoles({
           environment: environment,
           integrationId: selectedRequest.id as number,
           username: getServiceAccountUsername(selectedRequest.clientId as string),
           roleNames,
         });
-        if (!err) setSavingMessage(`Last saved at ${new Date().toLocaleString()}`);
-        await setSaving(false);
+        setSaving(false);
+        if (!err) {
+          setSavingMessage(`Last saved at ${new Date().toLocaleString()}`);
+          return true;
+        } else {
+          setUserAssignmentError(true);
+          setSavingMessage('Failed to update roles.');
+          return false;
+        }
       },
       2000,
       { trailing: true },
@@ -98,12 +108,18 @@ const ServiceAccountRoles = ({ selectedRequest, alert }: Props) => {
     if (actionMeta.action === 'clear') {
     } else if (actionMeta.action === 'remove-value') {
       newRoles = userRoles.filter((role) => role !== (actionMeta.removedValue?.value as string));
+    } else if (actionMeta.action === 'pop-value') {
+      newRoles = [...userRoles.slice(0, -1)];
     } else {
       newRoles = [...userRoles, actionMeta.option?.value as string];
     }
 
-    throttleUpdate(newRoles);
-    setUserRoles(newRoles);
+    if (newRoles.length !== userRoles.length) {
+      const succeeded = await throttleUpdate(newRoles);
+      if (succeeded) {
+        setUserRoles(newRoles);
+      }
+    }
   };
 
   const getRoles = async () => {
@@ -197,7 +213,11 @@ const ServiceAccountRoles = ({ selectedRequest, alert }: Props) => {
                         />
                       </div>
 
-                      <LastSavedMessage saving={saving} content={savingMessage} />
+                      <LastSavedMessage
+                        saving={saving}
+                        content={savingMessage}
+                        variant={userAssignmentError ? 'error' : 'success'}
+                      />
                     </div>
                   )}
                 </Grid.Col>

--- a/app/page-partials/my-dashboard/ServiceAccountRoles.tsx
+++ b/app/page-partials/my-dashboard/ServiceAccountRoles.tsx
@@ -82,13 +82,13 @@ const ServiceAccountRoles = ({ selectedRequest, alert }: Props) => {
           roleNames,
         });
         setSaving(false);
-        if (!err) {
-          setSavingMessage(`Last saved at ${new Date().toLocaleString()}`);
-          return true;
-        } else {
+        if (err) {
           setUserAssignmentError(true);
           setSavingMessage('Failed to update roles.');
           return false;
+        } else {
+          setSavingMessage(`Last saved at ${new Date().toLocaleString()}`);
+          return true;
         }
       },
       2000,
@@ -114,9 +114,9 @@ const ServiceAccountRoles = ({ selectedRequest, alert }: Props) => {
       newRoles = [...userRoles, actionMeta.option?.value as string];
     }
 
-    if (newRoles.length !== userRoles.length) {
-      const succeeded = await throttleUpdate(newRoles);
-      if (succeeded) {
+    if (userRoles.length !== newRoles.length) {
+      const success = await throttleUpdate(newRoles);
+      if (success) {
         setUserRoles(newRoles);
       }
     }

--- a/app/page-partials/my-dashboard/TeamInfoTabs/ServiceAccountsList.tsx
+++ b/app/page-partials/my-dashboard/TeamInfoTabs/ServiceAccountsList.tsx
@@ -13,6 +13,7 @@ import Table from 'components/TableNew';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import styled from 'styled-components';
 import { faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+import { TopAlert, withTopAlert } from '@app/layout/TopAlert';
 
 const RightFloatButtons = styled.td`
   float: right;
@@ -43,14 +44,16 @@ interface Props {
   setSelectedServiceAccount: (serviceAccount: Integration | null) => void;
   teamServiceAccounts: Integration[];
   getTeamServiceAccounts: (teamId: number) => void;
+  alert: TopAlert;
 }
 
-export default function ServiceAccountsList({
+function ServiceAccountsList({
   team,
   selectedServiceAccount,
   setSelectedServiceAccount,
   teamServiceAccounts,
   getTeamServiceAccounts,
+  alert,
 }: Props) {
   const deleteServiceAccountModalId = 'delete-service-account-modal';
   const updateServiceAccountSecretModalId = 'update-service-account-secret-modal';
@@ -65,7 +68,14 @@ export default function ServiceAccountsList({
   };
 
   const handleConfirmDelete = async () => {
-    await deleteServiceAccount(team.id, selectedServiceAccount?.id);
+    const [_result, error] = await deleteServiceAccount(team.id, selectedServiceAccount?.id);
+    if (error) {
+      alert.show({
+        variant: 'danger',
+        content: 'Failed to delete service account, please try again.',
+      });
+      return;
+    }
     getTeamServiceAccounts(team.id);
   };
 
@@ -75,12 +85,26 @@ export default function ServiceAccountsList({
   };
 
   const handleConfirmUpdate = async () => {
-    await updateServiceAccountCredentials(team.id, selectedServiceAccount?.id);
+    const [_, error] = await updateServiceAccountCredentials(team.id, selectedServiceAccount?.id);
+    if (error) {
+      alert.show({
+        variant: 'danger',
+        content: 'Failed to update secret, please try again.',
+      });
+      return;
+    }
   };
 
   const copyOrDownloadServiceAccount = async (download: boolean) => {
     if (checkDisabled(selectedServiceAccount)) return;
-    let [data] = await getServiceAccountCredentials(team.id, selectedServiceAccount?.id);
+    let [data, error] = await getServiceAccountCredentials(team.id, selectedServiceAccount?.id);
+    if (error) {
+      alert.show({
+        variant: 'danger',
+        content: `Failed to ${download ? 'download' : 'copy'}, please try again.`,
+      });
+      return;
+    }
     data = data || {};
 
     const text = {
@@ -179,3 +203,5 @@ export default function ServiceAccountsList({
     </>
   );
 }
+
+export default withTopAlert(ServiceAccountsList);

--- a/app/page-partials/my-dashboard/TeamInfoTabs/ServiceAccountsList.tsx
+++ b/app/page-partials/my-dashboard/TeamInfoTabs/ServiceAccountsList.tsx
@@ -54,7 +54,7 @@ function ServiceAccountsList({
   teamServiceAccounts,
   getTeamServiceAccounts,
   alert,
-}: Props) {
+}: Readonly<Props>) {
   const deleteServiceAccountModalId = 'delete-service-account-modal';
   const updateServiceAccountSecretModalId = 'update-service-account-secret-modal';
 
@@ -91,7 +91,6 @@ function ServiceAccountsList({
         variant: 'danger',
         content: 'Failed to update secret, please try again.',
       });
-      return;
     }
   };
 

--- a/app/page-partials/my-dashboard/TeamInfoTabs/index.tsx
+++ b/app/page-partials/my-dashboard/TeamInfoTabs/index.tsx
@@ -387,7 +387,10 @@ function TeamInfoTabs({ alert, currentUser, team, loadTeams }: Props) {
   const handleMemberRoleChange = async (memberId: number, role: string) => {
     const [data, err] = await updateTeamMember(team.id as number, memberId, { role });
     if (err) {
-      console.error(err);
+      alert.show({
+        variant: 'danger',
+        content: `Failed to update user role. Please try again.`,
+      });
       return;
     }
 
@@ -695,6 +698,11 @@ function TeamInfoTabs({ alert, currentUser, team, loadTeams }: Props) {
           />
         }
         onConfirm={onConfirmAdd}
+        onClose={() => {
+          setTempMembers([emptyMember]);
+          setMembers([]);
+          setErrors(null);
+        }}
         skipCloseOnConfirm={true}
         buttonStyle="custom"
         closable

--- a/app/page-partials/my-dashboard/UserRoles.tsx
+++ b/app/page-partials/my-dashboard/UserRoles.tsx
@@ -200,23 +200,31 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
   const [selectedProperty, setSelectedProperty] = useState<string>('');
   const [searchKey, setSearchKey] = useState<string>('');
   const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
+  const [userAssignmentError, setUserAssignmentError] = useState(false);
   const surveyContext = useContext(SurveyContext);
 
   const throttleUpdate = useCallback(
     throttle(
       async (roleNames: string[]) => {
         await setSaving(true);
+        setSavingMessage('Assigning role...');
+        setUserAssignmentError(false);
         const [, err] = await manageUserRoles({
           environment: selectedEnvironment,
           integrationId: selectedRequest.id as number,
           username: selectedId as string,
           roleNames,
         });
+        setSaving(false);
         if (!err) {
           setSavingMessage(`Last saved at ${new Date().toLocaleString()}`);
           surveyContext?.setShowSurvey(true, 'addUserToRole');
+          return true;
+        } else {
+          setUserAssignmentError(true);
+          setSavingMessage('Failed to update roles.');
+          return false;
         }
-        await setSaving(false);
       },
       2000,
       { trailing: true },
@@ -323,7 +331,6 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
     setRows([]);
     setUserRoles([]);
     setSelectedId(undefined);
-    setSearched(true);
 
     const [data, err] = await searchKeycloakUsers({
       environment: selectedEnvironment,
@@ -333,7 +340,15 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
       integrationId: selectedRequest.id || -1,
     });
 
+    if (err) {
+      alert.show({
+        variant: 'danger',
+        content: 'Failed to fetch users.',
+      });
+    }
+
     if (data) {
+      setSearched(true);
       setRows(sliceRows(_page, data.rows));
       setCount(data.count);
     }
@@ -361,8 +376,10 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
 
     // Only send update if roles have been added or removed. Prevents excessive API calls if jamming backspace button when empty.
     if (newRoles.length !== userRoles.length) {
-      throttleUpdate(newRoles);
-      setUserRoles(newRoles);
+      const succeeded = await throttleUpdate(newRoles);
+      if (succeeded) {
+        setUserRoles(newRoles);
+      }
     }
   };
 
@@ -388,7 +405,7 @@ const UserRoles = ({ selectedRequest, alert }: Props) => {
           onChange={handleRoleChange}
           data-testid="user-role-select"
         />
-        <LastSavedMessage saving={saving} content={savingMessage} />
+        <LastSavedMessage saving={saving} content={savingMessage} variant={userAssignmentError ? 'error' : 'success'} />
       </>
     );
   }

--- a/app/pages/admin-dashboard.tsx
+++ b/app/pages/admin-dashboard.tsx
@@ -19,6 +19,8 @@ import { SingleValue } from 'react-select';
 import debounce from 'lodash.debounce';
 import { getIdirUsersByEmail } from '@app/services/user';
 import styled from 'styled-components';
+import { SystemUnavailableMessage } from '@app/page-partials/my-dashboard/Messages';
+import { TopAlert, withTopAlert } from '@app/layout/TopAlert';
 
 const idpOptions = [
   { value: 'idir', label: 'IDIR' },
@@ -73,103 +75,119 @@ const throttledIdirSearch = debounce(
  *  3. If the integration is not team owned, require an email.
  *  4. If the integration for a team service account, and the team is deleted, do not allow restoration.
  */
-const RestoreModalContent = ({
-  selectedIntegration,
-  loadData,
-}: {
-  selectedIntegration?: Integration;
-  loadData: () => Promise<void>;
-}) => {
-  const [teamExists, setTeamExists] = useState<boolean>(false);
-  const [loading, setLoading] = useState<boolean>(false);
-  const [selectedEmail, setSelectedEmail] = useState<string>('');
-  const [error, setError] = useState('');
+const RestoreModalContent = withTopAlert(
+  ({
+    selectedIntegration,
+    loadData,
+    alert,
+  }: {
+    selectedIntegration?: Integration;
+    loadData: () => Promise<void>;
+    alert: TopAlert;
+  }) => {
+    const [teamExists, setTeamExists] = useState<boolean>(false);
+    const [loading, setLoading] = useState<boolean>(false);
+    const [selectedEmail, setSelectedEmail] = useState<string>('');
+    const [error, setError] = useState('');
 
-  const checkTeamExistence = async () => {
-    setLoading(true);
-    const [teamExists, _err] = await getAllowedTeam(String(selectedIntegration!.teamId));
-    setTeamExists(!!teamExists);
-    setLoading(false);
-  };
+    const checkTeamExistence = async () => {
+      setLoading(true);
+      const [teamExists, _err] = await getAllowedTeam(String(selectedIntegration!.teamId));
+      setTeamExists(!!teamExists);
+      setLoading(false);
+    };
 
-  useEffect(() => {
-    setError('');
-    setSelectedEmail('');
-    if (selectedIntegration?.usesTeam) {
-      checkTeamExistence();
-    }
-  }, [selectedIntegration?.id]);
+    useEffect(() => {
+      setError('');
+      setSelectedEmail('');
+      if (selectedIntegration?.usesTeam) {
+        checkTeamExistence();
+      }
+    }, [selectedIntegration?.id]);
 
-  useEffect(() => {
-    setError('');
-  }, [selectedEmail]);
+    useEffect(() => {
+      setError('');
+    }, [selectedEmail]);
 
-  const confirmRestore = async () => {
-    const emailRequired = !(selectedIntegration?.usesTeam && teamExists);
+    const confirmRestore = async () => {
+      const emailRequired = !(selectedIntegration?.usesTeam && teamExists);
+      let hasError = false;
 
-    if (emailRequired && !selectedEmail) {
-      setError('Please select an email address to restore the integration to.');
-      return;
-    }
+      if (emailRequired && !selectedEmail) {
+        setError('Please select an email address to restore the integration to.');
+        return;
+      }
 
-    if (selectedIntegration?.apiServiceAccount) {
-      await restoreServiceAccount(Number(selectedIntegration?.teamId), selectedIntegration?.id);
+      if (selectedIntegration?.apiServiceAccount) {
+        const [_result, error] = await restoreServiceAccount(
+          Number(selectedIntegration?.teamId),
+          selectedIntegration?.id,
+        );
+        hasError = !!error;
+      } else {
+        const [_result, error] = await restoreRequest(selectedIntegration?.id, selectedEmail);
+        hasError = !!error;
+      }
+      if (hasError) {
+        alert.show({
+          variant: 'danger',
+          content: 'Failed to restore integration, please try again.',
+        });
+      }
+      await loadData();
+      handleClose();
+      window.location.hash = '#';
+    };
+
+    const handleClose = () => {
+      setSelectedEmail('');
+      setError('');
+    };
+
+    if (!selectedIntegration) return null;
+
+    let content: string | ReactNode = '';
+    if (loading) {
+      content = 'Checking if the team exists...';
+    } else if (selectedIntegration.usesTeam && teamExists) {
+      content = 'You are about to restore this integration.';
+    } else if (selectedIntegration.apiServiceAccount && !teamExists) {
+      content = 'Cannot restore this team account, team does not exist.';
     } else {
-      await restoreRequest(selectedIntegration?.id, selectedEmail);
+      content = (
+        <RequestRestorationContainer>
+          <label htmlFor="restoration-email-select">Select an email to assign the integration to.</label>
+          <AsyncSelect
+            loadOptions={throttledIdirSearch}
+            value={{ value: selectedEmail, label: selectedEmail }}
+            onChange={(option: SingleValue<{ value: string; label: string }>) => setSelectedEmail(option?.label || '')}
+            noOptionsMessage={() => 'Start typing email...'}
+            maxMenuHeight={120}
+            placeholder={'Enter email address'}
+            id="restoration-email-select"
+          />
+          {error && <p className="error-text">Select an email address</p>}
+        </RequestRestorationContainer>
+      );
     }
-    await loadData();
-    handleClose();
-    window.location.hash = '#';
-  };
 
-  const handleClose = () => {
-    setSelectedEmail('');
-    setError('');
-  };
-
-  if (!selectedIntegration) return null;
-
-  let content: string | ReactNode = '';
-  if (loading) {
-    content = 'Checking if the team exists...';
-  } else if (selectedIntegration.usesTeam && teamExists) {
-    content = 'You are about to restore this integration.';
-  } else if (selectedIntegration.apiServiceAccount && !teamExists) {
-    content = 'Cannot restore this team account, team does not exist.';
-  } else {
-    content = (
-      <RequestRestorationContainer>
-        <label htmlFor="restoration-email-select">Select an email to assign the integration to.</label>
-        <AsyncSelect
-          loadOptions={throttledIdirSearch}
-          value={{ value: selectedEmail, label: selectedEmail }}
-          onChange={(option: SingleValue<{ value: string; label: string }>) => setSelectedEmail(option?.label || '')}
-          noOptionsMessage={() => 'Start typing email...'}
-          maxMenuHeight={120}
-          placeholder={'Enter email address'}
-          id="restoration-email-select"
-        />
-        {error && <p className="error-text">Select an email address</p>}
-      </RequestRestorationContainer>
+    return (
+      <CenteredModal
+        id="restore-modal"
+        data-testid="modal-restore-integration"
+        content={content}
+        onConfirm={confirmRestore}
+        confirmText="Restore"
+        title="Confirm Restoration"
+        skipCloseOnConfirm
+        showConfirm={!(selectedIntegration.apiServiceAccount && !teamExists)}
+        onClose={handleClose}
+      />
     );
-  }
+  },
+);
 
-  return (
-    <CenteredModal
-      id="restore-modal"
-      data-testid="modal-restore-integration"
-      content={content}
-      onConfirm={confirmRestore}
-      confirmText="Restore"
-      title="Confirm Restoration"
-      skipCloseOnConfirm
-      showConfirm={!(selectedIntegration.apiServiceAccount && !teamExists)}
-      onClose={handleClose}
-    />
-  );
-};
-
-export default function AdminDashboard({ session }: PageProps) {
+function AdminDashboard({ session, alert }: PageProps & { alert: TopAlert }) {
   const router = useRouter();
   const [loading, setLoading] = useState<boolean>(false);
   const [hasError, setHasError] = useState<boolean>(false);
@@ -245,7 +263,7 @@ export default function AdminDashboard({ session }: PageProps) {
   }, [rows]);
 
   if (hasError) {
-    return null;
+    return <SystemUnavailableMessage />;
   }
 
   const canEdit = (request: Integration) =>
@@ -284,10 +302,17 @@ export default function AdminDashboard({ session }: PageProps) {
 
   const confirmDelete = async () => {
     if (!canDelete) return;
-    selectedRequest?.apiServiceAccount
+    const [_result, error] = selectedRequest?.apiServiceAccount
       ? await deleteServiceAccount(selectedRequest?.teamId as number, selectedId)
       : await deleteRequest(selectedId);
-    await getData();
+    if (error) {
+      alert.show({
+        variant: 'danger',
+        content: 'Failed to delete the integration, please try again.',
+      });
+    } else {
+      await getData();
+    }
     window.location.hash = '#';
   };
 
@@ -459,3 +484,5 @@ export default function AdminDashboard({ session }: PageProps) {
     </>
   );
 }
+
+export default withTopAlert(AdminDashboard);

--- a/app/pages/admin-dashboard.tsx
+++ b/app/pages/admin-dashboard.tsx
@@ -155,7 +155,10 @@ const RestoreModalContent = ({
   } else {
     content = (
       <RequestRestorationContainer>
-        <label htmlFor="restoration-email-select">Select an email to assign the integration to.</label>
+        <label htmlFor="restoration-email-select">
+          Please validate the requestor who is asking to restore (get one more government employee confirming their
+          role). Please enter new requestor email address. Note this requestor can then assign to a new team as needed.
+        </label>
         <AsyncSelect
           loadOptions={throttledIdirSearch}
           value={{ value: selectedEmail, label: selectedEmail }}

--- a/app/pages/admin-reports.tsx
+++ b/app/pages/admin-reports.tsx
@@ -14,6 +14,8 @@ import {
 import styled from 'styled-components';
 import Select from 'react-select';
 import { ActionButton } from 'components/ActionButtons';
+import { AxiosError } from 'axios';
+import { FailureMessage } from '@app/page-partials/my-dashboard/Messages';
 
 const BorderLine = styled.div`
   border-bottom: 1px solid #707070;
@@ -78,6 +80,7 @@ function DownloadIcon(props: { type: string; handleClick: any }) {
 export default function AdminReports({ session }: PageProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [reportType, setreportType] = useState<any>('');
+  const [downloadError, setDownloadError] = useState(false);
 
   const ReportTypeOptions = () => {
     return (
@@ -103,29 +106,25 @@ export default function AdminReports({ session }: PageProps) {
     );
   };
 
-  const handleAllStandardReportClick = async () => {
+  const handleDownloadClick = async (reportDownloadFunction: () => Promise<[true, null] | [null, AxiosError]>) => {
     setLoading(true);
-    await downloadAllStandardIntegrationsReport();
+    setDownloadError(false);
+    const [_, err] = await reportDownloadFunction();
+    if (err) {
+      setDownloadError(true);
+    }
     setLoading(false);
   };
 
-  const handleAllBceidApprovedRequestsAndEventsReportClick = async () => {
-    setLoading(true);
-    await downloadAllBceidApprovedRequestsAndEventsReport();
-    setLoading(false);
-  };
-
-  const handleIntegrationDataIntegrityReportClick = async () => {
-    setLoading(true);
-    await downloadIntegrationDataIntegrityReport();
-    setLoading(false);
-  };
-
-  const handleDownloadReportClick = async () => {
-    setLoading(true);
-    await downloadDatabaseReport(reportTypeMap[reportType], primaryKeyMap[reportTypeMap[reportType]]);
-    setLoading(false);
-  };
+  const handleAllStandardReportClick = async () => handleDownloadClick(downloadAllStandardIntegrationsReport);
+  const handleAllBceidApprovedRequestsAndEventsReportClick = async () =>
+    handleDownloadClick(downloadAllBceidApprovedRequestsAndEventsReport);
+  const handleIntegrationDataIntegrityReportClick = async () =>
+    handleDownloadClick(downloadIntegrationDataIntegrityReport);
+  const handleDownloadReportClick = async () =>
+    handleDownloadClick(() =>
+      downloadDatabaseReport(reportTypeMap[reportType], primaryKeyMap[reportTypeMap[reportType]]),
+    );
 
   return (
     <ResponsiveContainer rules={mediaRules}>
@@ -185,6 +184,12 @@ export default function AdminReports({ session }: PageProps) {
               </p>
             </>
           )}
+        </>
+      )}
+      {downloadError && (
+        <>
+          <br />
+          <FailureMessage message="Failed to download report. Please try again." />
         </>
       )}
     </ResponsiveContainer>

--- a/app/services/axios.ts
+++ b/app/services/axios.ts
@@ -47,12 +47,6 @@ instance.interceptors.response.use(
           });
           break;
         default:
-          Router.push({
-            pathname: '/application-error',
-            query: {
-              error: 'E05',
-            },
-          });
           break;
       }
     }

--- a/app/services/report.ts
+++ b/app/services/report.ts
@@ -9,7 +9,7 @@ var currentDate = `${newDate.getFullYear()}${
   newDate.getMonth() + 1
 }${newDate.getDate()}${newDate.getHours()}${newDate.getMinutes()}`;
 
-export const downloadAllStandardIntegrationsReport = async (): Promise<void | [null, AxiosError]> => {
+export const downloadAllStandardIntegrationsReport = async (): Promise<[true, null] | [null, AxiosError]> => {
   try {
     const result = await instance.get('reports/all-standard-integrations').then((res) => res.data);
 
@@ -18,13 +18,17 @@ export const downloadAllStandardIntegrationsReport = async (): Promise<void | [n
 
     XLSX.utils.book_append_sheet(workBook, workSheet, 'All standard integrations');
     XLSX.writeFile(workBook, `all-standard-integrations-${currentDate}.xlsx`);
+    return [true, null];
   } catch (err: any) {
     console.log(err);
     return handleAxiosError(err);
   }
 };
 
-export const downloadDatabaseReport = async (type: string, orderBy: string): Promise<void | [null, AxiosError]> => {
+export const downloadDatabaseReport = async (
+  type: string,
+  orderBy: string,
+): Promise<[true, null] | [null, AxiosError]> => {
   try {
     const result = await instance.get('reports/database-tables', { params: { type, orderBy } }).then((res) => res.data);
 
@@ -33,13 +37,14 @@ export const downloadDatabaseReport = async (type: string, orderBy: string): Pro
 
     XLSX.utils.book_append_sheet(workBook, workSheet, `All ${type}`);
     XLSX.writeFile(workBook, `all-${type.toLowerCase()}-${currentDate}.xlsx`);
+    return [true, null];
   } catch (err: any) {
     console.log(err);
     return handleAxiosError(err);
   }
 };
 
-export const downloadAllBceidApprovedRequestsAndEventsReport = async (): Promise<void | [null, AxiosError]> => {
+export const downloadAllBceidApprovedRequestsAndEventsReport = async (): Promise<[true, null] | [null, AxiosError]> => {
   try {
     const result = await instance.get('reports/all-bceid-approved-requests-and-events').then((res) => res.data);
 
@@ -48,16 +53,18 @@ export const downloadAllBceidApprovedRequestsAndEventsReport = async (): Promise
 
     XLSX.utils.book_append_sheet(workBook, workSheet, 'All BCeID Approved Reqs&Events');
     XLSX.writeFile(workBook, `all-bceid-approved-requests-and-events-${currentDate}.xlsx`);
+    return [true, null];
   } catch (err: any) {
     console.log(err);
     return handleAxiosError(err);
   }
 };
 
-export const downloadIntegrationDataIntegrityReport = async (): Promise<void | [null, AxiosError]> => {
+export const downloadIntegrationDataIntegrityReport = async (): Promise<[true, null] | [null, AxiosError]> => {
   try {
     const result = await instance.get('reports/data-integrity').then((res) => res.data);
     downloadText(prettyJSON(result), `sso-css-data-integrity-${new Date().getTime()}.json`);
+    return [true, null];
   } catch (err: any) {
     console.log(err);
     return handleAxiosError(err);


### PR DESCRIPTION
This removes the default rerouting to an error page from the axios interceptor so that general api error codes don't always push the user there. The bulk of the changes here are going through the existing AJAX requests and flashing our alert banner for ones that relied on the re-route previously.

I added a couple of quick fixes while going through the frontend:
- Update key to be correct
- Set some errors to more generic messages
- Clear out some form data for team members when the modal is cancelled