### PR TITLE
chore: update emails

### DIFF
--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -277,6 +277,7 @@ export const updateRequest = async (
       let environments = current.environments.concat();
 
       const hasProd = environments.includes('prod');
+      const addingProd = !originalData.environments.includes('prod') && hasProd;
 
       const hasBceid = usesBceid(current);
       const hasBceidProd = hasBceid && hasProd;
@@ -320,6 +321,7 @@ export const updateRequest = async (
               waitingBceidProdApproval,
               waitingGithubProdApproval,
               waitingDigitalCredentialProdApproval,
+              addingProd,
             },
           });
         }

--- a/lambda/shared/local.ts
+++ b/lambda/shared/local.ts
@@ -4,4 +4,4 @@ export const IDIM_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
 
 export const OCIO_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
 
-export const DIT_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
+export const DIT_EMAIL_ADDRESS = 'ditrust@gov.bc.ca';

--- a/lambda/shared/templates/create-integration-submitted/index.ts
+++ b/lambda/shared/templates/create-integration-submitted/index.ts
@@ -38,7 +38,9 @@ export const send = async (data: DataProps, rendered: RenderResult) => {
   const cc = [SSO_EMAIL_ADDRESS];
   if (usesBceid(integration)) cc.push(IDIM_EMAIL_ADDRESS);
   if (usesGithub(integration)) cc.push(OCIO_EMAIL_ADDRESS);
-  if (usesDigitalCredential(integration)) cc.push(DIT_EMAIL_ADDRESS);
+  if (usesDigitalCredential(integration) && integration.environments.includes('prod')) {
+    cc.push(DIT_EMAIL_ADDRESS);
+  }
 
   return sendEmail({
     code: EMAILS.CREATE_INTEGRATION_SUBMITTED,

--- a/lambda/shared/templates/delete-integration-submitted/index.ts
+++ b/lambda/shared/templates/delete-integration-submitted/index.ts
@@ -3,7 +3,7 @@ import Handlebars = require('handlebars');
 import { processRequest } from '../helpers';
 import { IntegrationData } from '@lambda-shared/interfaces';
 import { sendEmail } from '@lambda-shared/utils/ches';
-import { SSO_EMAIL_ADDRESS, IDIM_EMAIL_ADDRESS, OCIO_EMAIL_ADDRESS, DIT_EMAIL_ADDRESS } from '@lambda-shared/local';
+import { SSO_EMAIL_ADDRESS, IDIM_EMAIL_ADDRESS, OCIO_EMAIL_ADDRESS } from '@lambda-shared/local';
 import { getIntegrationEmails } from '../helpers';
 import { EMAILS } from '@lambda-shared/enums';
 import { usesBceid, usesGithub, usesDigitalCredential } from '@app/helpers/integration';
@@ -36,7 +36,6 @@ export const send = async (data: DataProps, rendered: RenderResult) => {
   const cc = [SSO_EMAIL_ADDRESS];
   if (usesBceid(integration)) cc.push(IDIM_EMAIL_ADDRESS);
   if (usesGithub(integration)) cc.push(OCIO_EMAIL_ADDRESS);
-  if (usesDigitalCredential(integration)) cc.push(DIT_EMAIL_ADDRESS);
 
   return sendEmail({
     code: EMAILS.DELETE_INTEGRATION_SUBMITTED,

--- a/lambda/shared/templates/delete-integration-submitted/index.ts
+++ b/lambda/shared/templates/delete-integration-submitted/index.ts
@@ -6,7 +6,7 @@ import { sendEmail } from '@lambda-shared/utils/ches';
 import { SSO_EMAIL_ADDRESS, IDIM_EMAIL_ADDRESS, OCIO_EMAIL_ADDRESS } from '@lambda-shared/local';
 import { getIntegrationEmails } from '../helpers';
 import { EMAILS } from '@lambda-shared/enums';
-import { usesBceid, usesGithub, usesDigitalCredential } from '@app/helpers/integration';
+import { usesBceid, usesGithub } from '@app/helpers/integration';
 import type { RenderResult } from '../index';
 
 const SUBJECT_TEMPLATE = `Pathfinder SSO integration ID {{integration.id}} deleted`;

--- a/lambda/shared/templates/update-integration-submitted/index.ts
+++ b/lambda/shared/templates/update-integration-submitted/index.ts
@@ -17,6 +17,7 @@ const bodyHandler = Handlebars.compile(template, { noEscape: true });
 
 interface DataProps {
   integration: IntegrationData;
+  addingProd?: boolean;
 }
 
 export const render = async (originalData: DataProps): Promise<RenderResult> => {
@@ -30,12 +31,14 @@ export const render = async (originalData: DataProps): Promise<RenderResult> => 
 };
 
 export const send = async (data: DataProps, rendered: RenderResult) => {
-  const { integration } = data;
+  const { integration, addingProd } = data;
   const emails = await getIntegrationEmails(integration);
   const cc = [SSO_EMAIL_ADDRESS];
   if (usesBceid(integration)) cc.push(IDIM_EMAIL_ADDRESS);
   if (usesGithub(integration)) cc.push(OCIO_EMAIL_ADDRESS);
-  if (usesDigitalCredential(integration)) cc.push(DIT_EMAIL_ADDRESS);
+  if (usesDigitalCredential(integration) && addingProd) {
+    cc.push(DIT_EMAIL_ADDRESS);
+  }
 
   return sendEmail({
     code: EMAILS.UPDATE_INTEGRATION_SUBMITTED,


### PR DESCRIPTION
update email cases for digital credentials to only be CC the dc team when production is originally submitted or added