### PR TITLE
feat: confirm deletion

### DIFF
--- a/app/components/ActionButtons.tsx
+++ b/app/components/ActionButtons.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTrash, faEdit } from '@fortawesome/free-solid-svg-icons';
 import { Integration } from 'interfaces/Request';
-import CenteredModal from 'components/CenteredModal';
 import { deleteRequest } from 'services/request';
 import { PRIMARY_RED } from 'styles/theme';
 import noop from 'lodash.noop';

--- a/app/components/ActionButtons.tsx
+++ b/app/components/ActionButtons.tsx
@@ -9,6 +9,7 @@ import { deleteRequest } from 'services/request';
 import { PRIMARY_RED } from 'styles/theme';
 import noop from 'lodash.noop';
 import { canDeleteIntegration, canEditIntegration } from '@app/helpers/permissions';
+import DeleteModal from './DeleteModal';
 
 export const ActionButtonContainer = styled.div`
   height: 100%;
@@ -113,12 +114,12 @@ export default function Actionbuttons({
           style={delIconStyle}
         />
       </ActionButtonContainer>
-      <CenteredModal
+      <DeleteModal
+        projectName={request.projectName}
         id={deleteModalId}
-        data-testid="modal-delete-integration"
-        content="You are about to delete this integration request. This action cannot be undone."
         onConfirm={confirmDelete}
         title="Confirm Deletion"
+        content="You are about to delete this integration request. This action cannot be undone."
         confirmText="Delete"
       />
     </>

--- a/app/components/ActionButtons.tsx
+++ b/app/components/ActionButtons.tsx
@@ -119,7 +119,6 @@ export default function Actionbuttons({
         onConfirm={confirmDelete}
         title="Confirm Deletion"
         content="You are about to delete this integration request. This action cannot be undone."
-        confirmText="Delete"
       />
     </>
   );

--- a/app/components/CenteredModal.tsx
+++ b/app/components/CenteredModal.tsx
@@ -47,6 +47,10 @@ const ButtonContainer = styled.div<{ buttonAlign: 'default' | 'center' }>`
     min-width: 150px;
     margin-right: 20px;
     display: inline-block;
+
+    &:disabled {
+      cursor: not-allowed;
+    }
   }
 `;
 
@@ -67,6 +71,7 @@ interface Props {
   buttonAlign?: 'center' | 'default';
   skipCloseOnConfirm?: boolean;
   style?: CSSProperties;
+  disableConfirm?: boolean;
 }
 
 const CenteredModal = ({
@@ -84,6 +89,7 @@ const CenteredModal = ({
   buttonAlign = 'default',
   skipCloseOnConfirm = false,
   style = {},
+  disableConfirm = false,
 }: Props) => {
   const [loading, setLoading] = useState(false);
   const showButtons = showCancel || showConfirm;
@@ -144,6 +150,7 @@ const CenteredModal = ({
                 variant={confirmButtonVariant}
                 type="button"
                 className="text-center"
+                disabled={disableConfirm}
               >
                 {loading ? (
                   <SpinnerGrid color="#FFF" height={18} width={50} wrapperClass="d-block" visible={loading} />

--- a/app/components/DeleteModal.tsx
+++ b/app/components/DeleteModal.tsx
@@ -1,0 +1,45 @@
+import CenteredModal from './CenteredModal';
+import { useState } from 'react';
+import Input from '@button-inc/bcgov-theme/Input';
+
+interface Props {
+  id: string;
+  onConfirm: () => void;
+  content: string;
+  title: string;
+  confirmText: string;
+  projectName?: string;
+}
+
+export default function DeleteModal({ id, onConfirm, title, content, projectName }: Props) {
+  const [nameConfirmation, setNameConfirmation] = useState('');
+
+  const handleConfirm = () => {
+    if (nameConfirmation === projectName) {
+      onConfirm();
+    }
+  };
+  return (
+    <div>
+      <CenteredModal
+        id={id}
+        data-testid="modal-delete-integration"
+        content={
+          <>
+            <p>{content}</p>
+            <Input
+              data-testid="delete-confirmation-input"
+              label="Please enter the project name to confirm deletion."
+              value={nameConfirmation}
+              onChange={(e: any) => setNameConfirmation(e.target.value)}
+            />
+          </>
+        }
+        onConfirm={handleConfirm}
+        title={title}
+        confirmText="Delete"
+        disableConfirm={nameConfirmation !== projectName}
+      />
+    </div>
+  );
+}

--- a/app/components/DeleteModal.tsx
+++ b/app/components/DeleteModal.tsx
@@ -1,5 +1,5 @@
 import CenteredModal from './CenteredModal';
-import { useState } from 'react';
+import { ChangeEvent, useState } from 'react';
 import Input from '@button-inc/bcgov-theme/Input';
 
 interface Props {
@@ -31,7 +31,7 @@ export default function DeleteModal({ id, onConfirm, title, content, projectName
               data-testid="delete-confirmation-input"
               label="Please enter the project name to confirm deletion."
               value={nameConfirmation}
-              onChange={(e: any) => setNameConfirmation(e.target.value)}
+              onChange={(e: ChangeEvent<HTMLInputElement>) => setNameConfirmation(e.target.value)}
             />
           </>
         }

--- a/app/components/DeleteModal.tsx
+++ b/app/components/DeleteModal.tsx
@@ -7,11 +7,10 @@ interface Props {
   onConfirm: () => void;
   content: string;
   title: string;
-  confirmText: string;
   projectName?: string;
 }
 
-export default function DeleteModal({ id, onConfirm, title, content, projectName }: Props) {
+export default function DeleteModal({ id, onConfirm, title, content, projectName }: Readonly<Props>) {
   const [nameConfirmation, setNameConfirmation] = useState('');
 
   const handleConfirm = () => {

--- a/app/jest/my-dashboard/my-projects/integrationList.test.tsx
+++ b/app/jest/my-dashboard/my-projects/integrationList.test.tsx
@@ -58,6 +58,12 @@ describe('Integration list', () => {
       expect(screen.getByTitle('Confirm Deletion'));
     });
 
+    const confirmationInput = await screen.findByTestId('delete-confirmation-input');
+    const confirmDeleteButton = await screen.findByTestId('confirm-delete-confirm-deletion');
+
+    fireEvent.change(confirmationInput, { target: { value: sampleRequest.projectName } });
+    expect((confirmDeleteButton as HTMLButtonElement).disabled).toBeFalsy();
+
     await waitFor(async () => {
       fireEvent.click(await screen.findByTestId('confirm-delete-confirm-deletion'));
     });

--- a/app/jest/my-dashboard/my-teams/integrations.test.tsx
+++ b/app/jest/my-dashboard/my-teams/integrations.test.tsx
@@ -188,6 +188,10 @@ describe('Integrations tab', () => {
     const actionDeleteButton = screen.getAllByTestId('action-button-delete');
     fireEvent.click(actionDeleteButton[0]);
     expect(screen.findByTitle('Confirm Deletion'));
+
+    const confirmationInput = await screen.findByTestId('delete-confirmation-input');
+    fireEvent.change(confirmationInput, { target: { value: 'test project' } });
+
     const confirmDeleteButton = screen.getAllByTestId('confirm-delete-confirm-deletion');
     fireEvent.click(confirmDeleteButton[0]);
     expect(deleteRequest).toHaveBeenCalledTimes(1);

--- a/app/jest/my-dashboard/my-teams/integrations.test.tsx
+++ b/app/jest/my-dashboard/my-teams/integrations.test.tsx
@@ -189,7 +189,7 @@ describe('Integrations tab', () => {
     fireEvent.click(actionDeleteButton[0]);
     expect(screen.findByTitle('Confirm Deletion'));
 
-    const confirmationInput = await screen.findByTestId('delete-confirmation-input');
+    const confirmationInput = await screen.getAllByTestId('delete-confirmation-input')[0];
     fireEvent.change(confirmationInput, { target: { value: 'test project' } });
 
     const confirmDeleteButton = screen.getAllByTestId('confirm-delete-confirm-deletion');

--- a/app/jest/ssoDashboard.test.tsx
+++ b/app/jest/ssoDashboard.test.tsx
@@ -170,8 +170,12 @@ describe('SSO Dashboard', () => {
     await waitFor(() => {
       expect(screen.getByTitle('Confirm Deletion')).toBeInTheDocument();
     });
-    const confirmDeleteButton = screen.getAllByTestId('confirm-delete-confirm-deletion');
-    fireEvent.click(confirmDeleteButton[0]);
+    const confirmDeleteButton = screen.getByTestId('confirm-delete-confirm-deletion');
+
+    const confirmationInput = await screen.getByTestId('delete-confirmation-input');
+    fireEvent.change(confirmationInput, { target: { value: 'project_name_1' } });
+
+    fireEvent.click(confirmDeleteButton);
     await waitFor(() => {
       expect(deleteRequest).toHaveBeenCalled();
     });

--- a/app/pages/admin-dashboard.tsx
+++ b/app/pages/admin-dashboard.tsx
@@ -473,7 +473,6 @@ function AdminDashboard({ session, alert }: PageProps & { alert: TopAlert }) {
         onConfirm={confirmDelete}
         title="Confirm Deletion"
         content="You are about to delete this integration request. This action cannot be undone."
-        confirmText="Delete"
       />
       <RestoreModalContent selectedIntegration={selectedRequest} loadData={loadData} alert={alert} />
     </>

--- a/app/pages/admin-dashboard.tsx
+++ b/app/pages/admin-dashboard.tsx
@@ -20,6 +20,7 @@ import styled from 'styled-components';
 import { SystemUnavailableMessage } from '@app/page-partials/my-dashboard/Messages';
 import { TopAlert, withTopAlert } from '@app/layout/TopAlert';
 import { throttledIdirSearch } from '@app/utils/users';
+import DeleteModal from '@app/components/DeleteModal';
 
 const idpOptions = [
   { value: 'idir', label: 'IDIR' },
@@ -46,6 +47,11 @@ function ActionsHeader() {
 }
 
 const RequestRestorationContainer = styled.div`
+  .restoration-email-select {
+    * {
+      visibility: inherit;
+    }
+  }
   label {
     margin-bottom: 0.5em;
   }
@@ -154,6 +160,7 @@ const RestoreModalContent = ({
           maxMenuHeight={120}
           placeholder={'Enter email address'}
           id="restoration-email-select"
+          className="restoration-email-select"
         />
         {error && <p className="error-text">Select an email address</p>}
       </RequestRestorationContainer>
@@ -460,13 +467,13 @@ function AdminDashboard({ session, alert }: PageProps & { alert: TopAlert }) {
           )
         }
       />
-      <CenteredModal
+      <DeleteModal
+        projectName={selectedRequest?.projectName}
         id="delete-modal"
-        data-testid="modal-delete-integration"
-        content="You are about to delete this integration request. This action cannot be undone."
         onConfirm={confirmDelete}
-        confirmText="Delete"
         title="Confirm Deletion"
+        content="You are about to delete this integration request. This action cannot be undone."
+        confirmText="Delete"
       />
       <RestoreModalContent selectedIntegration={selectedRequest} loadData={loadData} alert={alert} />
     </>


### PR DESCRIPTION
- Adds input to type in project name before being allowed to delete
- Fixes css visibility issue with restore modal 

UI below:

Without name button disabled:
![image](https://github.com/bcgov/sso-requests/assets/37274633/316b4208-1a4b-4a93-891e-dec75f4cc5be)


With name typed in allowed:
![image](https://github.com/bcgov/sso-requests/assets/37274633/b051d7ec-e395-4230-aa70-c027c5d54260)
