### PR TITLE
fix: remove disable integration step before deletion

### DIFF
--- a/lambda/__tests__/11.remove-inactive-users.test.ts
+++ b/lambda/__tests__/11.remove-inactive-users.test.ts
@@ -124,7 +124,7 @@ describe('users and teams', () => {
       expect(deleteResponse.status).toEqual(200);
       const user = await models.user.findOne({ where: { idir_userid: TEAM_ADMIN_IDIR_USERID_01 }, raw: true });
       expect(user).toBeNull();
-      expect(emailList.length).toEqual(2);
+      expect(emailList.length).toEqual(1);
       expect(emailList[0].subject).toEqual(template.subject);
       expect(emailList[0].body).toEqual(template.body);
       expect(emailList[0].to.length).toEqual(1);

--- a/lambda/app/src/controllers/user.ts
+++ b/lambda/app/src/controllers/user.ts
@@ -7,7 +7,6 @@ import { getDisplayName } from '../utils/helpers';
 import { findAllowedIntegrationInfo } from '@lambda-app/queries/request';
 import { listRoleUsers, listUserRoles, manageUserRole, manageUserRoles } from '@lambda-app/keycloak/users';
 import { canCreateOrDeleteRoles } from '@app/helpers/permissions';
-import { disableIntegration } from '@lambda-app/keycloak/client';
 import { EMAILS } from '@lambda-shared/enums';
 import { sendTemplate } from '@lambda-shared/templates';
 import { getAllEmailsOfTeam } from '@lambda-app/queries/team';
@@ -286,12 +285,10 @@ export const deleteStaleUsers = async (user: any) => {
             rqst.archived = true;
             if (rqst.status !== 'draft') {
               rqst.status = 'submitted';
-
-              await disableIntegration(rqst.get({ plain: true, clone: true }));
-              await processIntegrationRequest(rqst);
             }
           }
           await rqst.save();
+          await processIntegrationRequest(rqst);
         }
       }
 


### PR DESCRIPTION
The non team integrations created by inactive IDIR users shall be assigned to SSO Team User and then archived without disabling them in the process.