### PR TITLE
chore: privacy zone name

### DIFF
--- a/app/components/RequestPreview.tsx
+++ b/app/components/RequestPreview.tsx
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 import { authTypeDisplay } from 'metadata/display';
 import { Team } from 'interfaces/team';
 import { idpMap } from 'helpers/meta';
+import { usesBcServicesCard } from '@app/helpers/integration';
 
 const Table = styled.table`
   font-size: unset;
@@ -94,13 +95,15 @@ interface Props {
   request: Integration;
   teams?: Team[];
   children?: React.ReactNode;
+  privacyZone?: string;
 }
 
-function RequestPreview({ children, request, teams = [] }: Props) {
+function RequestPreview({ children, request, teams = [], privacyZone }: Props) {
   if (!request) return null;
   const idpDisplay = request.devIdps ?? [];
   const isOIDC = request.protocol !== 'saml';
   const fullIdpDisplay = idpDisplay.map((name: any) => idpMap[name]);
+  const hasBCSC = usesBcServicesCard(request);
 
   let teamName = '';
   if (request.usesTeam) {
@@ -171,6 +174,14 @@ function RequestPreview({ children, request, teams = [] }: Props) {
             </tr>
           )}
           <FormattedList list={fullIdpDisplay} title="Identity Providers Required:" inline testid="idp-required" />
+          {hasBCSC && (
+            <tr>
+              <td>Privacy Zone:</td>
+              <td>
+                <SemiBold>{privacyZone || 'Unavailable'}</SemiBold>
+              </td>
+            </tr>
+          )}
           {request.environments?.includes('dev') && (
             <FormattedList list={request.devValidRedirectUris} title="Dev Redirect URIs:" testid="dev-uri" />
           )}

--- a/app/components/RequestPreview.tsx
+++ b/app/components/RequestPreview.tsx
@@ -98,7 +98,7 @@ interface Props {
   privacyZone?: string;
 }
 
-function RequestPreview({ children, request, teams = [], privacyZone }: Props) {
+function RequestPreview({ children, request, teams = [], privacyZone }: Readonly<Props>) {
   if (!request) return null;
   const idpDisplay = request.devIdps ?? [];
   const isOIDC = request.protocol !== 'saml';

--- a/app/components/RequestPreview.tsx
+++ b/app/components/RequestPreview.tsx
@@ -178,7 +178,7 @@ function RequestPreview({ children, request, teams = [], privacyZone }: Readonly
             <tr>
               <td>Privacy Zone:</td>
               <td>
-                <SemiBold>{privacyZone || 'Unavailable'}</SemiBold>
+                <SemiBold>{privacyZone}</SemiBold>
               </td>
             </tr>
           )}

--- a/app/form-components/FieldReviewAndSubmit.tsx
+++ b/app/form-components/FieldReviewAndSubmit.tsx
@@ -5,6 +5,7 @@ import { NumberedContents } from '@bcgov-sso/common-react-components';
 import RequestPreview from 'components/RequestPreview';
 import { usesBceid } from '@app/helpers/integration';
 import FieldTemplate from './FieldTemplate';
+import { BcscPrivacyZone } from '@app/interfaces/types';
 
 export default function FieldReviewAndSubmit(props: FieldTemplateProps) {
   const { formContext } = props;
@@ -12,11 +13,14 @@ export default function FieldReviewAndSubmit(props: FieldTemplateProps) {
 
   const hasBceid = usesBceid(formData);
   const hasBceidProd = hasBceid && formData.environments?.includes('prod');
+  const privacyZone = formContext.bcscPrivacyZones?.find(
+    (zone: BcscPrivacyZone) => zone?.privacy_zone_uri === formData.bcscPrivacyZone,
+  );
 
   const top = (
     <div>
       <NumberedContents title="Please review your information to make sure it is correct." number={1}>
-        <RequestPreview request={formData} teams={teams} />
+        <RequestPreview request={formData} teams={teams} privacyZone={privacyZone?.privacy_zone_name} />
       </NumberedContents>
 
       <NumberedContents

--- a/app/form-components/FieldReviewAndSubmit.tsx
+++ b/app/form-components/FieldReviewAndSubmit.tsx
@@ -1,11 +1,9 @@
 import React from 'react';
-import styled from 'styled-components';
 import { FieldTemplateProps } from 'react-jsonschema-form';
 import { NumberedContents } from '@bcgov-sso/common-react-components';
 import RequestPreview from 'components/RequestPreview';
-import { usesBceid } from '@app/helpers/integration';
+import { getPrivacyZoneDisplayName, usesBceid } from '@app/helpers/integration';
 import FieldTemplate from './FieldTemplate';
-import { BcscPrivacyZone } from '@app/interfaces/types';
 
 export default function FieldReviewAndSubmit(props: FieldTemplateProps) {
   const { formContext } = props;
@@ -13,14 +11,11 @@ export default function FieldReviewAndSubmit(props: FieldTemplateProps) {
 
   const hasBceid = usesBceid(formData);
   const hasBceidProd = hasBceid && formData.environments?.includes('prod');
-  const privacyZone = formContext.bcscPrivacyZones?.find(
-    (zone: BcscPrivacyZone) => zone?.privacy_zone_uri === formData.bcscPrivacyZone,
-  );
-
+  const privacyZoneName = getPrivacyZoneDisplayName(formContext.bcscPrivacyZones, formData.bcscPrivacyZone);
   const top = (
     <div>
       <NumberedContents title="Please review your information to make sure it is correct." number={1}>
-        <RequestPreview request={formData} teams={teams} privacyZone={privacyZone?.privacy_zone_name} />
+        <RequestPreview request={formData} teams={teams} privacyZone={privacyZoneName} />
       </NumberedContents>
 
       <NumberedContents

--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -457,7 +457,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
         onChange={handleChange}
         onSubmit={handleFormSubmit}
         formData={formData}
-        formContext={{ isAdmin, teams, formData, setFormData, loadTeams }}
+        formContext={{ isAdmin, teams, formData, setFormData, loadTeams, bcscPrivacyZones }}
         FieldTemplate={FieldTemplate}
         ArrayFieldTemplate={ArrayFieldTemplate}
         liveValidate={visited[formStage] || isApplied}

--- a/app/helpers/integration.ts
+++ b/app/helpers/integration.ts
@@ -1,4 +1,6 @@
 import { Integration } from '@app/interfaces/Request';
+import { BcscPrivacyZone } from '@app/interfaces/types';
+import { bcscPrivacyZones } from '@app/utils/constants';
 
 export const checkBceidBoth = (idp: string) => idp === 'bceidboth';
 export const checkDigitalCredential = (idp: string) => idp === 'digitalcredential';
@@ -77,4 +79,14 @@ export const usesDigitalCredentialProd = (integration: Integration) => {
   const { environments = [] } = integration;
 
   return usesDigitalCredential(integration) && environments.includes('prod');
+};
+
+/** Given an array of zones and a URI, finds the display name on the provided array or in the fallback constant array if not found. */
+export const getPrivacyZoneDisplayName = (zones: BcscPrivacyZone[], privacyZoneUri?: string) => {
+  const zoneMatch = (zone: BcscPrivacyZone) => zone?.privacy_zone_uri === privacyZoneUri;
+  let privacyZone = zones?.find(zoneMatch);
+  if (!privacyZone) {
+    privacyZone = bcscPrivacyZones().find(zoneMatch);
+  }
+  return privacyZone?.privacy_zone_name || 'Unavailable';
 };

--- a/app/page-partials/admin-dashboard/AdminRequestPanel.tsx
+++ b/app/page-partials/admin-dashboard/AdminRequestPanel.tsx
@@ -4,7 +4,6 @@ import RequestPreview from 'components/RequestPreview';
 import { Integration } from 'interfaces/Request';
 import MetadataEditModal from 'page-partials/admin-dashboard/MetadataEditModal';
 import { LoggedInUser } from 'interfaces/team';
-import { usesBcServicesCard } from '@app/helpers/integration';
 import { fetchPrivacyZones } from '@app/services/bc-services-card';
 import { BcscPrivacyZone } from '@app/interfaces/types';
 
@@ -22,7 +21,6 @@ interface Props {
 export default function AdminRequestPanel({ currentUser, request, onUpdate }: Props) {
   const [privacyZones, setPrivacyZones] = useState<BcscPrivacyZone[]>([]);
   const [privacyZoneName, setPrivacyZoneName] = useState('');
-  if (!request) return null;
 
   useEffect(() => {
     fetchPrivacyZones().then(([zones]): void => {
@@ -33,9 +31,11 @@ export default function AdminRequestPanel({ currentUser, request, onUpdate }: Pr
   }, []);
 
   useEffect(() => {
-    const bcscPrivacyZone = privacyZones.find((zone) => zone.privacy_zone_uri === request.bcscPrivacyZone);
+    const bcscPrivacyZone = privacyZones.find((zone) => zone.privacy_zone_uri === request?.bcscPrivacyZone);
     setPrivacyZoneName(bcscPrivacyZone?.privacy_zone_name || '');
-  }, [request.id, privacyZones]);
+  }, [request?.id, privacyZones]);
+
+  if (!request) return null;
 
   return (
     <EventContent>

--- a/app/page-partials/admin-dashboard/AdminRequestPanel.tsx
+++ b/app/page-partials/admin-dashboard/AdminRequestPanel.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import RequestPreview from 'components/RequestPreview';
 import { Integration } from 'interfaces/Request';
 import MetadataEditModal from 'page-partials/admin-dashboard/MetadataEditModal';
 import { LoggedInUser } from 'interfaces/team';
+import { usesBcServicesCard } from '@app/helpers/integration';
+import { fetchPrivacyZones } from '@app/services/bc-services-card';
+import { BcscPrivacyZone } from '@app/interfaces/types';
 
 const EventContent = styled.div`
   max-height: calc(100vh - 250px);
@@ -17,12 +20,27 @@ interface Props {
 }
 
 export default function AdminRequestPanel({ currentUser, request, onUpdate }: Props) {
+  const [privacyZones, setPrivacyZones] = useState<BcscPrivacyZone[]>([]);
+  const [privacyZoneName, setPrivacyZoneName] = useState('');
   if (!request) return null;
+
+  useEffect(() => {
+    fetchPrivacyZones().then(([zones]): void => {
+      if (zones) {
+        setPrivacyZones(zones);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    const bcscPrivacyZone = privacyZones.find((zone) => zone.privacy_zone_uri === request.bcscPrivacyZone);
+    setPrivacyZoneName(bcscPrivacyZone?.privacy_zone_name || '');
+  }, [request.id, privacyZones]);
 
   return (
     <EventContent>
       <br />
-      <RequestPreview request={request}>
+      <RequestPreview request={request} privacyZone={privacyZoneName}>
         <br />
         {currentUser.isAdmin && <MetadataEditModal request={request} onUpdate={onUpdate} />}
       </RequestPreview>

--- a/app/page-partials/admin-dashboard/AdminRequestPanel.tsx
+++ b/app/page-partials/admin-dashboard/AdminRequestPanel.tsx
@@ -6,6 +6,7 @@ import MetadataEditModal from 'page-partials/admin-dashboard/MetadataEditModal';
 import { LoggedInUser } from 'interfaces/team';
 import { fetchPrivacyZones } from '@app/services/bc-services-card';
 import { BcscPrivacyZone } from '@app/interfaces/types';
+import { getPrivacyZoneDisplayName } from '@app/helpers/integration';
 
 const EventContent = styled.div`
   max-height: calc(100vh - 250px);
@@ -31,8 +32,8 @@ export default function AdminRequestPanel({ currentUser, request, onUpdate }: Pr
   }, []);
 
   useEffect(() => {
-    const bcscPrivacyZone = privacyZones.find((zone) => zone.privacy_zone_uri === request?.bcscPrivacyZone);
-    setPrivacyZoneName(bcscPrivacyZone?.privacy_zone_name || '');
+    const bcscPrivacyZone = getPrivacyZoneDisplayName(privacyZones, request?.bcscPrivacyZone);
+    setPrivacyZoneName(bcscPrivacyZone);
   }, [request?.id, privacyZones]);
 
   if (!request) return null;

--- a/lambda/__tests__/06.email-templates.test.ts
+++ b/lambda/__tests__/06.email-templates.test.ts
@@ -14,6 +14,7 @@ import { generateInvitationToken } from '@lambda-app/helpers/token';
 import { createTeam, verifyTeamMember } from './helpers/modules/teams';
 import { getAuthenticatedUser } from './helpers/modules/users';
 import { cleanUpDatabaseTables, createMockAuth } from './helpers/utils';
+import { bcscPrivacyZones } from '@app/utils/constants';
 
 const MOCK_PRIVACY_ZONE_URI = 'zone';
 
@@ -163,6 +164,23 @@ describe('Email template snapshots', () => {
         testIdps: ['bcservicescard'],
         prodIdps: ['bcservicescard'],
         bcscPrivacyZone: MOCK_PRIVACY_ZONE_URI,
+      },
+      waitingBcServicesCardProdApproval: true,
+    });
+
+    expect(rendered.subject).toMatchSnapshot();
+    expect(rendered.body).toMatchSnapshot();
+  });
+
+  it('Should return the expected email for CREATE_INTEGRATION_SUBMITTED w/ BC Services Card with fallback privacy zone', async () => {
+    const constantZone = bcscPrivacyZones()[0];
+    const rendered = await renderTemplate(EMAILS.CREATE_INTEGRATION_SUBMITTED, {
+      integration: {
+        ...formDataProd,
+        devIdps: ['bcservicescard'],
+        testIdps: ['bcservicescard'],
+        prodIdps: ['bcservicescard'],
+        bcscPrivacyZone: constantZone.privacy_zone_uri,
       },
       waitingBcServicesCardProdApproval: true,
     });

--- a/lambda/__tests__/06.email-templates.test.ts
+++ b/lambda/__tests__/06.email-templates.test.ts
@@ -15,9 +15,27 @@ import { createTeam, verifyTeamMember } from './helpers/modules/teams';
 import { getAuthenticatedUser } from './helpers/modules/users';
 import { cleanUpDatabaseTables, createMockAuth } from './helpers/utils';
 
+const MOCK_PRIVACY_ZONE_URI = 'zone';
+
 jest.mock('@lambda-app/authenticate');
 
 jest.mock('@lambda-shared/utils/ches');
+
+jest.mock('@lambda-shared/templates/helpers', () => {
+  const original = jest.requireActual('@lambda-shared/templates/helpers');
+  return {
+    ...original,
+    getAccountableEntity: jest.fn(() => Promise.resolve('username')),
+  };
+});
+
+jest.mock('@lambda-app/controllers/bc-services-card', () => {
+  return {
+    getPrivacyZones: jest.fn(() =>
+      Promise.resolve([{ privacy_zone_uri: MOCK_PRIVACY_ZONE_URI, privacy_zone_name: 'zone' }]),
+    ),
+  };
+});
 
 describe('Email template snapshots', () => {
   let teamId: number;
@@ -144,6 +162,7 @@ describe('Email template snapshots', () => {
         devIdps: ['bcservicescard'],
         testIdps: ['bcservicescard'],
         prodIdps: ['bcservicescard'],
+        bcscPrivacyZone: MOCK_PRIVACY_ZONE_URI,
       },
       waitingBcServicesCardProdApproval: true,
     });
@@ -154,7 +173,7 @@ describe('Email template snapshots', () => {
 
   it('Should return the expected email for CREATE_INTEGRATION_APPLIED - w/ approved BC Services Card prod', async () => {
     const rendered = await renderTemplate(EMAILS.CREATE_INTEGRATION_APPLIED, {
-      integration: { ...formDataDev, devIdps: ['bcservicescard'] },
+      integration: { ...formDataDev, devIdps: ['bcservicescard'], bcscPrivacyZone: MOCK_PRIVACY_ZONE_URI },
       waitingBcServicesCardProdApproval: false,
     });
 
@@ -164,7 +183,7 @@ describe('Email template snapshots', () => {
 
   it('Should return the expected email for CREATE_INTEGRATION_APPLIED - w/ unapproved BC Services Card prod', async () => {
     const rendered = await renderTemplate(EMAILS.CREATE_INTEGRATION_APPLIED, {
-      integration: { ...formDataDev, devIdps: ['bcservicescard'] },
+      integration: { ...formDataDev, devIdps: ['bcservicescard'], bcscPrivacyZone: MOCK_PRIVACY_ZONE_URI },
       waitingBcServicesCardProdApproval: true,
     });
 
@@ -223,6 +242,7 @@ describe('Email template snapshots', () => {
         devIdps: ['bcservicescard'],
         testIdps: ['bcservicescard'],
         prodIdps: ['bcservicescard'],
+        bcscPrivacyZone: MOCK_PRIVACY_ZONE_URI,
       },
       waitingBcServicesCardProdApproval: true,
     });
@@ -251,7 +271,7 @@ describe('Email template snapshots', () => {
 
   it('Should return the expected email for PROD_APPROVED w/ BC Services Card', async () => {
     const rendered = await renderTemplate(EMAILS.PROD_APPROVED, {
-      integration: { ...formDataDev, devIdps: ['bcservicescard'] },
+      integration: { ...formDataDev, devIdps: ['bcservicescard'], bcscPrivacyZone: MOCK_PRIVACY_ZONE_URI },
       type: 'BC Services Card',
     });
     expect(rendered.subject).toMatchSnapshot();

--- a/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
+++ b/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
@@ -46,6 +46,7 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+
 <strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development<br />
 <strong>Accountable person(s): </strong>Test User<br />
@@ -94,6 +95,7 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+
 <strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development<br />
 <strong>Accountable person(s): </strong>Test User<br />
@@ -543,6 +545,7 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+
 <strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development, Test, Production<br />
 <strong>Accountable person(s): </strong>Test User<br />
@@ -1040,6 +1043,7 @@ exports[`Email template snapshots Should return the expected email for PROD_APPR
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+
 <strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development<br />
 <strong>Accountable person(s): </strong>Test User<br />
@@ -1688,6 +1692,7 @@ exports[`Email template snapshots Should return the expected email for UPDATE_IN
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+
 <strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development, Test, Production<br />
 <strong>Accountable person(s): </strong>Test User<br />

--- a/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
+++ b/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
@@ -620,6 +620,90 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
 "
 `;
 
+exports[`Email template snapshots Should return the expected email for CREATE_INTEGRATION_SUBMITTED w/ BC Services Card with fallback privacy zone 1`] = `"[DEV] Pathfinder SSO request submitted & additional important information (email 1 of 2)"`;
+
+exports[`Email template snapshots Should return the expected email for CREATE_INTEGRATION_SUBMITTED w/ BC Services Card with fallback privacy zone 2`] = `
+"<h3>Hello Pathfinder SSO friend,</h3>
+<p>Your Pathfinder SSO request ID 1 is successfully submitted.</p>
+<p>Below is a summary of your integration request details:</p>
+<strong>Project name: </strong>test<br />
+<strong>Primary End Users: </strong>None Selected<br />
+<strong>Identity Providers: </strong>BC Services Card<br />
+
+<strong>Privacy Zone:</strong> Health (Citizen) <br />
+<strong>Environments: </strong>Development, Test, Production<br />
+<strong>Accountable person(s): </strong>Test User<br />
+<strong>Submitted by: </strong>SSO Admin<br />
+<strong>URIs:</strong>
+<ul>
+  <li>
+    Development:
+    <ul>
+      <li>https://b</li>
+    </ul>
+  </li>
+  <li>
+    Test:
+    <ul>
+      <li>https://test</li>
+    </ul>
+  </li>
+  <li>
+    Production:
+    <ul>
+      <li>https://a</li>
+    </ul>
+  </li>
+</ul>
+ <p>
+  <strong>The expected processing time is 5 minutes</strong><br />
+  Once the request is approved, you will receive another email that your JSON Client Installation is ready. If you are
+  not the requester, this email serves only to notify you of the request status.
+</p>
+   <table border="0" width="100%" cellpadding="0" cellspacing="0">
+  <tr>
+    <td
+      style="background: none; border-bottom: 1px solid #d7dfe3; height: 1px; width: 100%; margin: 0px 0px 0px 0px"
+    ></td>
+  </tr>
+</table>
+<br />
+ <strong>Next Steps for your integration with BC Services Card:</strong>
+<p>
+  As you've requested an integration with BC Services Card, any production integration request requires you to work with
+  the Identity and Information Management (IDIM) team.
+</p>
+<ol>
+  <li>
+    <strong
+      >On a best effort basis, the BC Services Card team will endeavour to reach out to you within 2-3 business days to
+      schedule an on-boarding meeting.</strong
+    >
+  </li>
+  <li>
+    <strong>Please have answers to the questions below, before your meeting with the IDIM team.</strong>
+    <ul>
+      <li>What is your estimated volume of initial users?</li>
+      <li>Do you anticipate your volume of users will grow over the next three years?</li>
+      <li>When do you need access to the production environment by?</li>
+      <li>When will your end users need access to the production environment?</li>
+    </ul>
+    <div style="display: none">&nbsp;</div>
+  </li>
+</ol>
+  <p>
+  If you have any questions, please contact us by
+  <a href="https://chat.developer.gov.bc.ca/channel/sso" target="_blank" title="Rocket Chat" rel="noreferrer">
+    Rocket.Chat
+  </a>
+  or email at:
+  <a href="mailto:bcgov.sso@gov.bc.ca" title="Pathfinder SSO" target="_blank" rel="noreferrer"> bcgov.sso@gov.bc.ca </a>
+</p>
+<p>Thank you.<br />Pathfinder SSO Team</p>
+
+"
+`;
+
 exports[`Email template snapshots Should return the expected email for CREATE_INTEGRATION_SUBMITTED w/ BCeID & GitHub 1`] = `"[DEV] Pathfinder SSO request submitted & additional important information (email 1 of 2)"`;
 
 exports[`Email template snapshots Should return the expected email for CREATE_INTEGRATION_SUBMITTED w/ BCeID & GitHub 2`] = `

--- a/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
+++ b/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
@@ -46,6 +46,7 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+<strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development<br />
 <strong>Accountable person(s): </strong>Test User<br />
 <strong>Submitted by: </strong>SSO Admin<br />
@@ -93,6 +94,7 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+<strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development<br />
 <strong>Accountable person(s): </strong>Test User<br />
 <strong>Submitted by: </strong>SSO Admin<br />
@@ -541,6 +543,7 @@ exports[`Email template snapshots Should return the expected email for CREATE_IN
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+<strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development, Test, Production<br />
 <strong>Accountable person(s): </strong>Test User<br />
 <strong>Submitted by: </strong>SSO Admin<br />
@@ -1037,6 +1040,7 @@ exports[`Email template snapshots Should return the expected email for PROD_APPR
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+<strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development<br />
 <strong>Accountable person(s): </strong>Test User<br />
 <strong>Submitted by: </strong>SSO Admin<br />
@@ -1684,6 +1688,7 @@ exports[`Email template snapshots Should return the expected email for UPDATE_IN
 <strong>Project name: </strong>test<br />
 <strong>Primary End Users: </strong>None Selected<br />
 <strong>Identity Providers: </strong>BC Services Card<br />
+<strong>Privacy Zone:</strong> zone <br />
 <strong>Environments: </strong>Development, Test, Production<br />
 <strong>Accountable person(s): </strong>Test User<br />
 <strong>Submitted by: </strong>SSO Admin<br />

--- a/lambda/shared/templates/helpers.ts
+++ b/lambda/shared/templates/helpers.ts
@@ -9,6 +9,8 @@ import { getTeamById } from '@lambda-app/queries/team';
 import { getUserById } from '@lambda-app/queries/user';
 import { idpMap, envMap } from '@app/helpers/meta';
 import { Integration } from '@app/interfaces/Request';
+import { usesBcServicesCard } from '@app/helpers/integration';
+import { getPrivacyZoneName } from '.';
 
 export const processTeam = async (team: any) => {
   if (team instanceof models.team) {
@@ -27,7 +29,7 @@ export const processUser = async (user: any) => {
 };
 
 export const processRequest = async (integrationOrModel: any) => {
-  let integration!: Integration;
+  let integration!: Integration & { bcscPrivacyZoneName?: string };
   if (integrationOrModel instanceof models.request) {
     integration = integrationOrModel.get({ plain: true });
   } else {
@@ -52,6 +54,10 @@ export const processRequest = async (integrationOrModel: any) => {
     uris: integration[`${env}ValidRedirectUris`] || [],
   }));
   const browserLoginEnabled = authType !== 'service-account';
+  if (usesBcServicesCard(integration)) {
+    const bcscPrivacyZoneName = await getPrivacyZoneName(integration.bcscPrivacyZone);
+    integration.bcscPrivacyZoneName = bcscPrivacyZoneName;
+  }
 
   return {
     ...integration,

--- a/lambda/shared/templates/index.ts
+++ b/lambda/shared/templates/index.ts
@@ -22,6 +22,7 @@ import surveyCompleted from './survey-completed-notification';
 import restoreIntegration from './restore-integration';
 import restoreTeamApiAccount from './restore-team-api-account';
 import orphanIntegration from './orphan-integration';
+import { getPrivacyZones } from '@lambda-app/controllers/bc-services-card';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:3000';
 const API_URL = process.env.API_URL || 'http://localhost:8080/app';
@@ -70,6 +71,17 @@ const getRolePrivelege = (role: string) => {
   return 'view';
 };
 
+export const getPrivacyZoneName = async (uri?: string) => {
+  try {
+    if (!uri) return null;
+    const zones = await getPrivacyZones();
+    return zones.find((zone) => zone.privacy_zone_uri === uri)?.privacy_zone_name;
+  } catch (e) {
+    console.error(e);
+    return 'Unavailable';
+  }
+};
+
 const capitalize = (word: string) => word[0].toUpperCase() + word.slice(1).toLowerCase();
 
 Handlebars.registerPartial('footer', footer);
@@ -89,6 +101,7 @@ Handlebars.registerPartial('bceidWarning', bceidWarning);
 Handlebars.registerHelper('formatPrimaryUsers', formatPrimaryUsers);
 Handlebars.registerHelper('getRolePrivelege', getRolePrivelege);
 Handlebars.registerHelper('capitalize', capitalize);
+Handlebars.registerHelper('getPrivacyZoneName', getPrivacyZoneName);
 
 const getBuilder = (key: string) => {
   let builder = { render: (v) => v, send: noop };

--- a/lambda/shared/templates/index.ts
+++ b/lambda/shared/templates/index.ts
@@ -23,6 +23,7 @@ import restoreIntegration from './restore-integration';
 import restoreTeamApiAccount from './restore-team-api-account';
 import orphanIntegration from './orphan-integration';
 import { getPrivacyZones } from '@lambda-app/controllers/bc-services-card';
+import { getPrivacyZoneDisplayName } from '@app/helpers/integration';
 
 const APP_URL = process.env.APP_URL || 'http://localhost:3000';
 const API_URL = process.env.API_URL || 'http://localhost:8080/app';
@@ -75,7 +76,7 @@ export const getPrivacyZoneName = async (uri?: string) => {
   try {
     if (!uri) return null;
     const zones = await getPrivacyZones();
-    return zones.find((zone) => zone.privacy_zone_uri === uri)?.privacy_zone_name;
+    return getPrivacyZoneDisplayName(zones, uri);
   } catch (e) {
     console.error(e);
     return 'Unavailable';

--- a/lambda/shared/templates/integration-detail.html
+++ b/lambda/shared/templates/integration-detail.html
@@ -3,7 +3,7 @@
 <strong>Primary End Users: </strong>{{formatPrimaryUsers integration.primaryEndUsers
 integration.primaryEndUsersOther}}<br />
 <strong>Identity Providers: </strong>{{integration.idpNames}}<br />
-{{/if}} {{#if integration.bcscPrivacyZoneName}}
+{{/if}}{{#if integration.bcscPrivacyZoneName}}
 <strong>Privacy Zone:</strong> {{integration.bcscPrivacyZoneName}} <br />
 {{/if}}
 <strong>Environments: </strong>{{integration.envNames}}<br />

--- a/lambda/shared/templates/integration-detail.html
+++ b/lambda/shared/templates/integration-detail.html
@@ -3,6 +3,8 @@
 <strong>Primary End Users: </strong>{{formatPrimaryUsers integration.primaryEndUsers
 integration.primaryEndUsersOther}}<br />
 <strong>Identity Providers: </strong>{{integration.idpNames}}<br />
+{{/if}} {{#if integration.bcscPrivacyZoneName}}
+<strong>Privacy Zone:</strong> {{integration.bcscPrivacyZoneName}} <br />
 {{/if}}
 <strong>Environments: </strong>{{integration.envNames}}<br />
 <strong>Accountable person(s): </strong>{{integration.accountableEntity}}<br />


### PR DESCRIPTION
Adds the privacy zone name to the emails and admin dashboard display for BCSC integrations. I was going back and forth on just fetching it when mailing or saving the name to the database. Since it is just a display item and not used for any request logic I decided to add the extra fetch instead of migrating the db/updating the data model and rewriting the zone select widget. 