### PR TITLE
fix: ownership updates

### DIFF
--- a/lambda/__tests__/21.requests-validations.test.ts
+++ b/lambda/__tests__/21.requests-validations.test.ts
@@ -86,18 +86,6 @@ describe('integration validations', () => {
       await cleanUpDatabaseTables();
     });
 
-    it('should not update team info after integration is applied', async () => {
-      createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
-      const updateableIntegration = getUpdateIntegrationData({ integration });
-      let updateIntRes = await updateIntegration(
-        { ...updateableIntegration, usesTeam: false, projectLead: true },
-        true,
-      );
-      expect(updateIntRes.status).toEqual(200);
-      expect(updateIntRes.body.usesTeam).toEqual(true);
-      expect(updateIntRes.body.projectLead).toEqual(false);
-    });
-
     it('should not allow to change bceid idp and/or approved flag', async () => {
       createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
       const projectName: string = 'BCeID Integration Validations';

--- a/lambda/__tests__/21.requests-validations.test.ts
+++ b/lambda/__tests__/21.requests-validations.test.ts
@@ -65,7 +65,7 @@ jest.mock('@lambda-app/controllers/bc-services-card', () => {
 describe('integration validations', () => {
   try {
     let teamId: number;
-    let teamIntegration: Integration;
+    let integration: Integration;
 
     beforeAll(async () => {
       jest.clearAllMocks();
@@ -79,7 +79,7 @@ describe('integration validations', () => {
       const projectName: string = 'Integration Validations';
       const integrationRes = await buildIntegration({ projectName, teamId, submitted: true, prodEnv: true });
       expect(integrationRes.status).toEqual(200);
-      teamIntegration = integrationRes.body;
+      integration = integrationRes.body;
     });
 
     afterAll(async () => {
@@ -88,7 +88,7 @@ describe('integration validations', () => {
 
     it('should not allow removing a team after the integration is applied', async () => {
       createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
-      const updateableIntegration = getUpdateIntegrationData({ integration: teamIntegration });
+      const updateableIntegration = getUpdateIntegrationData({ integration: integration });
       let updateIntRes = await updateIntegration(
         { ...updateableIntegration, usesTeam: false, projectLead: true },
         true,
@@ -109,7 +109,7 @@ describe('integration validations', () => {
           },
         ],
       });
-      const updateableIntegration = getUpdateIntegrationData({ integration: teamIntegration });
+      const updateableIntegration = getUpdateIntegrationData({ integration: integration });
       let updateIntRes = await updateIntegration({ ...updateableIntegration, teamId: String(newTeam.body.id) }, true);
       expect(updateIntRes.status).toEqual(200);
       expect(updateIntRes.body.usesTeam).toEqual(true);

--- a/lambda/__tests__/21.requests-validations.test.ts
+++ b/lambda/__tests__/21.requests-validations.test.ts
@@ -65,7 +65,6 @@ jest.mock('@lambda-app/controllers/bc-services-card', () => {
 describe('integration validations', () => {
   try {
     let teamId: number;
-    let integration: Integration;
 
     beforeAll(async () => {
       jest.clearAllMocks();
@@ -79,7 +78,6 @@ describe('integration validations', () => {
       const projectName: string = 'Integration Validations';
       const integrationRes = await buildIntegration({ projectName, teamId, submitted: true, prodEnv: true });
       expect(integrationRes.status).toEqual(200);
-      integration = integrationRes.body;
     });
 
     afterAll(async () => {

--- a/lambda/__tests__/21.requests-validations.test.ts
+++ b/lambda/__tests__/21.requests-validations.test.ts
@@ -11,7 +11,6 @@ import {
 import { updateIntegration } from './helpers/modules/integrations';
 import { createTeam, verifyTeamMember } from './helpers/modules/teams';
 import { cleanUpDatabaseTables, createMockAuth } from './helpers/utils';
-import { Integration } from 'app/interfaces/Request';
 import { buildIntegration } from './helpers/modules/common';
 import { getAuthenticatedUser } from './helpers/modules/users';
 import { generateInvitationToken } from '@lambda-app/helpers/token';

--- a/lambda/__tests__/21.requests-validations.test.ts
+++ b/lambda/__tests__/21.requests-validations.test.ts
@@ -86,9 +86,9 @@ describe('integration validations', () => {
       await cleanUpDatabaseTables();
     });
 
-    it('should not allow removing a team after the integration is applied', async () => {
+    it('should not allow removing a team after integration is applied', async () => {
       createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
-      const updateableIntegration = getUpdateIntegrationData({ integration: integration });
+      const updateableIntegration = getUpdateIntegrationData({ integration });
       let updateIntRes = await updateIntegration(
         { ...updateableIntegration, usesTeam: false, projectLead: true },
         true,
@@ -117,7 +117,7 @@ describe('integration validations', () => {
       expect(updateIntRes.body.teamId).toEqual(newTeam.body.id);
     });
 
-    it('should allow adding a team after the integration is applied', async () => {
+    it('should allow adding a team to single-owner integrations after the integration is applied', async () => {
       createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
       const integrationRes = await buildIntegration({ projectName: 'single-owner', submitted: true, prodEnv: true });
       expect(integrationRes.body.usesTeam).toEqual(false);

--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -444,6 +444,10 @@ export const updateRequest = async (
     }
 
     if (originalData.status === 'applied') {
+      // Once an integration has been created for a team, cannot revert to single person ownership.
+      if (originalData.usesTeam && !rest.usesTeam) rest.usesTeam = originalData.usesTeam;
+      if (!originalData.projectLead && rest.projectLead) rest.projectLead = originalData.projectLead;
+
       // if integration in applied state do not allow changes to bcsc privacy zone
       rest.environments = originalData.environments.concat(
         rest.environments.filter((env) => {

--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -439,14 +439,12 @@ export const updateRequest = async (
     }
 
     if (originalData.status === 'applied') {
-      // if integration in applied state do not allow changes to environments and team
+      // if integration in applied state do not allow changes to bcsc privacy zone
       rest.environments = originalData.environments.concat(
         rest.environments.filter((env) => {
           if (!originalData.environments.includes(env) && ['dev', 'test', 'prod'].includes(env)) return env;
         }),
       );
-      rest.usesTeam = originalData.usesTeam;
-      rest.projectLead = originalData.projectLead;
       if (originalData.devIdps.includes('bcservicescard')) {
         rest.bcscPrivacyZone = originalData.bcscPrivacyZone;
       }
@@ -608,6 +606,7 @@ export const updateRequest = async (
 
     const changes = getDifferences(finalData, originalData);
     current.lastChanges = changes;
+    console.log(changes, current);
     let updated = await current.save();
 
     if (!updated) {

--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -606,7 +606,6 @@ export const updateRequest = async (
 
     const changes = getDifferences(finalData, originalData);
     current.lastChanges = changes;
-    console.log(changes, current);
     let updated = await current.save();
 
     if (!updated) {

--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -429,6 +429,11 @@ export const updateRequest = async (
     let existingClientId: string = '';
     const current = await getAllowedRequest(session, data.id);
     const getCurrentValue = () => current.get({ plain: true, clone: true });
+
+    if (current.status === 'applied' && !submit) {
+      throw Error('Temporary updates not allowed for applied requests.');
+    }
+
     const originalData = getCurrentValue();
     const isAllowedStatus = ['draft', 'applied'].includes(current.status);
 


### PR DESCRIPTION
- Allow updates to team and ownership for applied requests
- For applied requests, only allow submission not "draft edits"