### PR TITLE
fix: privacy zone uris

### DIFF
--- a/app/components/RequestPreview.tsx
+++ b/app/components/RequestPreview.tsx
@@ -95,10 +95,9 @@ interface Props {
   request: Integration;
   teams?: Team[];
   children?: React.ReactNode;
-  privacyZone?: string;
 }
 
-function RequestPreview({ children, request, teams = [], privacyZone }: Readonly<Props>) {
+function RequestPreview({ children, request, teams = [] }: Readonly<Props>) {
   if (!request) return null;
   const idpDisplay = request.devIdps ?? [];
   const isOIDC = request.protocol !== 'saml';
@@ -178,7 +177,7 @@ function RequestPreview({ children, request, teams = [], privacyZone }: Readonly
             <tr>
               <td>Privacy Zone:</td>
               <td>
-                <SemiBold>{privacyZone}</SemiBold>
+                <SemiBold>{request.bcscPrivacyZone}</SemiBold>
               </td>
             </tr>
           )}

--- a/app/form-components/FieldReviewAndSubmit.tsx
+++ b/app/form-components/FieldReviewAndSubmit.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { FieldTemplateProps } from 'react-jsonschema-form';
 import { NumberedContents } from '@bcgov-sso/common-react-components';
 import RequestPreview from 'components/RequestPreview';
-import { getPrivacyZoneDisplayName, usesBceid } from '@app/helpers/integration';
+import { usesBceid } from '@app/helpers/integration';
 import FieldTemplate from './FieldTemplate';
 
 export default function FieldReviewAndSubmit(props: FieldTemplateProps) {
@@ -11,11 +11,10 @@ export default function FieldReviewAndSubmit(props: FieldTemplateProps) {
 
   const hasBceid = usesBceid(formData);
   const hasBceidProd = hasBceid && formData.environments?.includes('prod');
-  const privacyZoneName = getPrivacyZoneDisplayName(formContext.bcscPrivacyZones, formData.bcscPrivacyZone);
   const top = (
     <div>
       <NumberedContents title="Please review your information to make sure it is correct." number={1}>
-        <RequestPreview request={formData} teams={teams} privacyZone={privacyZoneName} />
+        <RequestPreview request={formData} teams={teams} />
       </NumberedContents>
 
       <NumberedContents

--- a/app/jest/ssoDashboard.test.tsx
+++ b/app/jest/ssoDashboard.test.tsx
@@ -3,7 +3,6 @@ import AdminDashboard from 'pages/admin-dashboard';
 import { Integration } from 'interfaces/Request';
 import { sampleRequest } from './samples/integrations';
 import { deleteRequest, updateRequestMetadata, updateRequest, restoreRequest, getRequestAll } from 'services/request';
-import { bcscPrivacyZones } from '@app/utils/constants';
 import { getCompositeClientRoles } from '@app/services/keycloak';
 
 const MOCK_PRIVACY_ZONE_URI = 'uniqueZoneUri';

--- a/app/jest/ssoDashboard.test.tsx
+++ b/app/jest/ssoDashboard.test.tsx
@@ -385,33 +385,7 @@ describe('SSO Dashboard', () => {
     expect(privacyZoneElement).toBeInTheDocument();
 
     await waitFor(() => {
-      expect(screen.getByText(MOCK_PRIVACY_ZONE_NAME)).toBeInTheDocument();
-    });
-  });
-
-  it('Falls back to check the privacy zone constant for privacy zone name in the request details for BCSC integrations if not in api result', async () => {
-    const constantZone = bcscPrivacyZones()[0];
-    (getRequestAll as jest.Mock).mockImplementationOnce(() => {
-      return Promise.resolve([
-        {
-          count: 1,
-          // Returning a URI not avaiable on the mocked privacy-zones result
-          rows: [{ ...bcscRequest, bcscPrivacyZone: constantZone.privacy_zone_uri }],
-        },
-      ]);
-    });
-    render(<AdminDashboard session={sampleSession} onLoginClick={jest.fn} onLogoutClick={jest.fn} />);
-    await waitFor(() => {
-      screen.getByText('testProject');
-    });
-
-    const firstRow = screen.getByText('testProject');
-    fireEvent.click(firstRow);
-    const privacyZoneElement = screen.queryByText('Privacy Zone:');
-    expect(privacyZoneElement).toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(screen.getByText(constantZone.privacy_zone_name)).toBeInTheDocument();
+      expect(screen.getByText(bcscRequest.bcscPrivacyZone)).toBeInTheDocument();
     });
   });
 

--- a/app/page-partials/admin-dashboard/AdminRequestPanel.tsx
+++ b/app/page-partials/admin-dashboard/AdminRequestPanel.tsx
@@ -1,12 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import styled from 'styled-components';
 import RequestPreview from 'components/RequestPreview';
 import { Integration } from 'interfaces/Request';
 import MetadataEditModal from 'page-partials/admin-dashboard/MetadataEditModal';
 import { LoggedInUser } from 'interfaces/team';
-import { fetchPrivacyZones } from '@app/services/bc-services-card';
-import { BcscPrivacyZone } from '@app/interfaces/types';
-import { getPrivacyZoneDisplayName } from '@app/helpers/integration';
 
 const EventContent = styled.div`
   max-height: calc(100vh - 250px);
@@ -20,28 +17,12 @@ interface Props {
 }
 
 export default function AdminRequestPanel({ currentUser, request, onUpdate }: Props) {
-  const [privacyZones, setPrivacyZones] = useState<BcscPrivacyZone[]>([]);
-  const [privacyZoneName, setPrivacyZoneName] = useState('');
-
-  useEffect(() => {
-    fetchPrivacyZones().then(([zones]): void => {
-      if (zones) {
-        setPrivacyZones(zones);
-      }
-    });
-  }, []);
-
-  useEffect(() => {
-    const bcscPrivacyZone = getPrivacyZoneDisplayName(privacyZones, request?.bcscPrivacyZone);
-    setPrivacyZoneName(bcscPrivacyZone);
-  }, [request?.id, privacyZones]);
-
   if (!request) return null;
 
   return (
     <EventContent>
       <br />
-      <RequestPreview request={request} privacyZone={privacyZoneName}>
+      <RequestPreview request={request}>
         <br />
         {currentUser.isAdmin && <MetadataEditModal request={request} onUpdate={onUpdate} />}
       </RequestPreview>

--- a/app/schemas/providers-gold.ts
+++ b/app/schemas/providers-gold.ts
@@ -47,7 +47,7 @@ export default function getSchema(
   const privacyZonesSchema = {
     type: 'string',
     title: 'Please select privacy zone',
-    enum: bcscPrivacyZones?.map((zone) => zone.privacy_zone_uri || []),
+    enum: bcscPrivacyZones?.map((zone) => zone.privacy_zone_name || []),
     enumNames: bcscPrivacyZones?.map((zone) => zone.privacy_zone_name || []),
   };
 

--- a/lambda/app/src/bcsc/client.ts
+++ b/lambda/app/src/bcsc/client.ts
@@ -37,44 +37,10 @@ const getBCSCContacts = async (integration: IntegrationData) => {
   return contacts;
 };
 
-/*
-  Fallback mapping from prod -> test for existing BCSC privacy zones
-*/
-const privacyZoneMap = {
-  'urn:ca:bc:gov:health:prd': 'urn:ca:bc:gov:health:mockidtest',
-  'urn:ca:bc:gov:buseco:prod': 'urn:ca:bc:gov:buseco:test',
-  'urn:ca:bc:gov:fin:ctz:pz:prod': 'urn:ca:bc:gov:fin:ctz:pz:test',
-  'urn:ca:bc:gov:educ': 'urn:ca:bc:gov:educ:test',
-  'urn:ca:bc:gov:healthprovider': 'urn:ca:bc:gov:healthprovider:test',
-  'urn:ca:bc:gov:justice:prd': 'urn:ca:bc:gov:justice:test',
-  'urn:ca:bc:gov:nrs:ctz:pz:prod': 'urn:ca:bc:gov:nrs:ctz:pz:test',
-  'urn:ca:bc:gov:bcpsa:ctz:pz:prod': 'urn:ca:bc:gov:bcpsa:ctz:pz:test',
-  'urn:ca:bc:sbc:ctz:pz:prod': 'urn:ca:bc:sbc:ctz:pz:test',
-  'urn:ca:bc:gov:tran:pro:pz:prod': 'urn:ca:bc:gov:tran:pro:pz:test',
-  'urn:ca:bc:gov:social:prod': 'urn:ca:bc:gov:social:test',
-  'urn:ca:bc:gov:nrs:pro:prod': 'urn:ca:bc:gov:nrs:pro:test',
-  'urn:ca:bc:gov:citz:pro:prod': 'urn:ca:bc:gov:citz:pro:test',
-  'urn:ca:bc:gov:educprofessional:prod': 'urn:ca:bc:gov:educprofessional:test',
-};
-
-/*
-  Privacy Zone URIs are mostly in the format a:b:environment. This attempts to update
-  the environment to "test", and check it exists in the api response. If not it falls back to
-  the map of existing privacy zones.
-*/
-const getTestPrivacyZoneURI = async (uri: string) => {
-  const testUriData = await getPrivacyZones('test');
-  const expectedURIParts = uri.split(':');
-  expectedURIParts[expectedURIParts.length - 1] = 'test';
-  let expectedURI = expectedURIParts.join(':');
-
-  const testURIs = testUriData.map((zone) => zone.privacy_zone_uri);
-  if (testURIs.includes(expectedURI)) return expectedURI;
-
-  expectedURI = privacyZoneMap[uri];
-  if (expectedURI) return expectedURI;
-
-  return null;
+const getPrivacyZoneURI = async (env: string, privacyZoneDisplayName: string) => {
+  const uriData = await getPrivacyZones(env);
+  const privacyZone = uriData.find((zone) => zone.privacy_zone_name === privacyZoneDisplayName);
+  return privacyZone?.privacy_zone_uri;
 };
 
 export const createBCSCClient = async (data: BCSCClientParameters, integration: IntegrationData, userId: number) => {
@@ -82,17 +48,7 @@ export const createBCSCClient = async (data: BCSCClientParameters, integration: 
   const { bcscBaseUrl, kcBaseUrl, accessToken } = getBCSCEnvVars(data.environment);
   const jwksUri = `${kcBaseUrl}/auth/realms/standard/protocol/openid-connect/certs`;
   const requiredScopes = await getRequiredBCSCScopes(integration.bcscAttributes);
-  let bcscPrivacyZone = integration.bcscPrivacyZone;
-
-  // Update privacy zone for dev and test to the idtest identifier
-  if (data.environment !== 'prod' && process.env.APP_ENV === 'production') {
-    const testPrivacyZone = await getTestPrivacyZoneURI(bcscPrivacyZone);
-    if (testPrivacyZone === null) {
-      throw new Error('Privacy zone not found');
-    } else {
-      bcscPrivacyZone = testPrivacyZone;
-    }
-  }
+  let bcscPrivacyZoneDisplayName = await getPrivacyZoneURI(data.environment, integration.bcscPrivacyZone);
 
   const result = await axios.post(
     `${bcscBaseUrl}/oauth2/register`,
@@ -107,7 +63,7 @@ export const createBCSCClient = async (data: BCSCClientParameters, integration: 
       userinfo_signed_response_alg: 'RS256',
       // Sub must be requested. Otherwise id token will have a randomized identifier.
       claims: [...integration.bcscAttributes, 'sub'],
-      privacy_zone_uri: bcscPrivacyZone,
+      privacy_zone_uri: bcscPrivacyZoneDisplayName,
       jwks_uri: jwksUri,
     },
     {

--- a/lambda/app/src/bcsc/client.ts
+++ b/lambda/app/src/bcsc/client.ts
@@ -48,7 +48,7 @@ export const createBCSCClient = async (data: BCSCClientParameters, integration: 
   const { bcscBaseUrl, kcBaseUrl, accessToken } = getBCSCEnvVars(data.environment);
   const jwksUri = `${kcBaseUrl}/auth/realms/standard/protocol/openid-connect/certs`;
   const requiredScopes = await getRequiredBCSCScopes(integration.bcscAttributes);
-  let bcscPrivacyZoneDisplayName = await getPrivacyZoneURI(data.environment, integration.bcscPrivacyZone);
+  let bcscPrivacyZoneURI = await getPrivacyZoneURI(data.environment, integration.bcscPrivacyZone);
 
   const result = await axios.post(
     `${bcscBaseUrl}/oauth2/register`,
@@ -63,7 +63,7 @@ export const createBCSCClient = async (data: BCSCClientParameters, integration: 
       userinfo_signed_response_alg: 'RS256',
       // Sub must be requested. Otherwise id token will have a randomized identifier.
       claims: [...integration.bcscAttributes, 'sub'],
-      privacy_zone_uri: bcscPrivacyZoneDisplayName,
+      privacy_zone_uri: bcscPrivacyZoneURI,
       jwks_uri: jwksUri,
     },
     {

--- a/lambda/app/src/controllers/bc-services-card.ts
+++ b/lambda/app/src/controllers/bc-services-card.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export const getPrivacyZones = async (env: 'dev' | 'test' | 'prod' = 'prod') => {
+export const getPrivacyZones = async (env: string = 'prod') => {
   let bcscBaseUrl;
   if (env === 'dev') bcscBaseUrl = process.env.BCSC_REGISTRATION_BASE_URL_DEV;
   if (env === 'test') bcscBaseUrl = process.env.BCSC_REGISTRATION_BASE_URL_TEST;

--- a/lambda/app/src/controllers/bc-services-card.ts
+++ b/lambda/app/src/controllers/bc-services-card.ts
@@ -1,7 +1,11 @@
 import axios from 'axios';
 
-export const getPrivacyZones = async () => {
-  return await axios.get(`${process.env.BCSC_REGISTRATION_BASE_URL_PROD}/oauth2/privacy-zones`).then((res) => res.data);
+export const getPrivacyZones = async (env: 'dev' | 'test' | 'prod' = 'prod') => {
+  let bcscBaseUrl;
+  if (env === 'dev') bcscBaseUrl = process.env.BCSC_REGISTRATION_BASE_URL_DEV;
+  if (env === 'test') bcscBaseUrl = process.env.BCSC_REGISTRATION_BASE_URL_TEST;
+  if (env === 'prod') bcscBaseUrl = process.env.BCSC_REGISTRATION_BASE_URL_PROD;
+  return await axios.get(`${bcscBaseUrl}/oauth2/privacy-zones`).then((res) => res.data);
 };
 export const getAttributes = async () => {
   return await axios


### PR DESCRIPTION
Store the display name for the privacy zone instead of the URI, and fetch the correct URI at create time.

There was also some logic in the frontend admin-panel to grab the display name, I took that out and the relevant test since it is directly on the integration now