### PR TITLE
chore: local cypress

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -39,7 +39,6 @@ jobs:
         continue-on-error: false
         with:
           summary-title: 'E2E tests'
-          record: true
           wait-on: 'http://localhost:3000'
           parallel: true
           wait-on-timeout: 360
@@ -47,6 +46,13 @@ jobs:
           working-directory: app
           spec: |
             cypress/e2e/smoke/smoke-10-brokenlinks.cy.ts
-            cypress/e2e/ci/*.cy.ts
           browser: electron
           ci-build-id: ${{ github.event.number }}
+
+      - uses: actions/upload-artifact@v4
+        # add the line below to store screenshots only on failures
+        # if: failure()
+        with:
+          name: cypress-screenshots
+          path: cypress/screenshots
+          if-no-files-found: ignore


### PR DESCRIPTION
record in gh action instead of cy cloud