### PR TITLE
chore: bump keycloak library

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -7,3 +7,4 @@ terraform-docs 0.12.1
 tflint 0.41.0
 k6 0.34.1
 helm 3.10.2
+bun 1.1.34

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.17.0-slim
 
-RUN npm install --ignore-scripts -g bun
+RUN curl -fsSL https://bun.sh/install | bash
 RUN apt-get update && apt-get install curl make -y \
                    && apt-get install libsqlite3-dev bzip2 icu-devtools uuid-dev -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.17.0-slim
 
-RUN curl -fsSL https://bun.sh/install | bash
+RUN curl --proto "=https" -fsSL https://bun.sh/install | bash
 RUN apt-get update && apt-get install curl make -y \
                    && apt-get install libsqlite3-dev bzip2 icu-devtools uuid-dev -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM node:20.17.0-slim
 
+RUN npm i -g bun
 RUN apt-get update && apt-get install curl make -y \
                    && apt-get install libsqlite3-dev bzip2 icu-devtools uuid-dev -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.17.0-slim
 
-RUN curl --proto "=https" -fsSL https://bun.sh/install | bash
+RUN npm i -g bun
 RUN apt-get update && apt-get install curl make -y \
                    && apt-get install libsqlite3-dev bzip2 icu-devtools uuid-dev -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.17.0-slim
 
-RUN npm i -g bun
+RUN npm i -g bun --ignore-scripts
 RUN apt-get update && apt-get install curl make -y \
                    && apt-get install libsqlite3-dev bzip2 icu-devtools uuid-dev -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:20.17.0-slim
 
-RUN npm i -g bun --ignore-scripts
+RUN npm install --ignore-scripts -g bun
 RUN apt-get update && apt-get install curl make -y \
                    && apt-get install libsqlite3-dev bzip2 icu-devtools uuid-dev -y
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2-slim
+FROM node:20.17.0-slim
 
 RUN apt-get update && apt-get install curl make -y \
                    && apt-get install libsqlite3-dev bzip2 icu-devtools uuid-dev -y

--- a/app/services/axios.ts
+++ b/app/services/axios.ts
@@ -21,8 +21,7 @@ instance.interceptors.request.use(
     }
     const authHeader = await getAuthHeader();
     if (authHeader) {
-      if (config.headers) config.headers.Authorization = authHeader;
-      else config.headers = { Authorization: authHeader };
+      config.headers.set('Authorization', authHeader);
     }
     return config;
   },

--- a/app/services/axios.ts
+++ b/app/services/axios.ts
@@ -21,7 +21,8 @@ instance.interceptors.request.use(
     }
     const authHeader = await getAuthHeader();
     if (authHeader) {
-      config.headers.set('Authorization', authHeader);
+      if (config.headers) config.headers.Authorization = authHeader;
+      else config.headers = { Authorization: authHeader };
     }
     return config;
   },

--- a/lambda/app/package.json
+++ b/lambda/app/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@azure/msal-node": "^2.6.4",
-    "@keycloak/keycloak-admin-client": "18.0.1",
+    "@keycloak/keycloak-admin-client": "^24.0.5",
     "cors": "^2.8.5",
     "deep-diff": "^1.0.2",
     "express": "^4.21.0",

--- a/lambda/app/yarn.lock
+++ b/lambda/app/yarn.lock
@@ -29,18 +29,14 @@
   resolved "https://registry.npmjs.org/@ioredis/commands/-/commands-1.2.0.tgz"
   integrity sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==
 
-"@keycloak/keycloak-admin-client@18.0.1":
-  version "18.0.1"
-  resolved "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-18.0.1.tgz"
-  integrity sha512-gmKjWbeLv5FvwlqDl+f6ZPFsgCOjFObYOPpmXj+v9itQd1PrSq6d1l1b7xIYyhAZnZ1pkKnDmzqtVrk+XrkAEg==
+"@keycloak/keycloak-admin-client@^24.0.5":
+  version "24.0.5"
+  resolved "https://registry.yarnpkg.com/@keycloak/keycloak-admin-client/-/keycloak-admin-client-24.0.5.tgz#b61a3bf02faaf659525ccc815c75cc3d5a545a80"
+  integrity sha512-SXDVtQ3ov7GQbxXq51Uq8lzhwzQwNg6XiY50ZA9whuUe2t/0zPT4Zd/LcULcjweIjSNWWgfbDyN1E3yRSL8Qqw==
   dependencies:
-    axios "^0.26.1"
-    camelize-ts "^1.0.8"
-    keycloak-js "^17.0.1"
-    lodash "^4.17.21"
-    query-string "^7.0.1"
-    url-join "^4.0.0"
-    url-template "^2.0.8"
+    camelize-ts "^3.0.0"
+    url-join "^5.0.0"
+    url-template "^3.1.1"
 
 "@types/body-parser@*":
   version "1.19.2"
@@ -156,18 +152,6 @@ asn1.js@^5.3.0:
     minimalistic-assert "^1.0.0"
     safer-buffer "^2.1.0"
 
-axios@^0.26.1:
-  version "0.26.1"
-  resolved "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz"
-  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
-  dependencies:
-    follow-redirects "^1.14.8"
-
-base64-js@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
-  integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
-
 bn.js@^4.0.0, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz"
@@ -217,10 +201,10 @@ call-bind@^1.0.7:
     get-intrinsic "^1.2.4"
     set-function-length "^1.2.1"
 
-camelize-ts@^1.0.8:
-  version "1.0.9"
-  resolved "https://registry.npmjs.org/camelize-ts/-/camelize-ts-1.0.9.tgz"
-  integrity sha512-ePOW3V2qrQ0qtRlcTM6Qe3nXremdydIwsMKI1Vl2NBGM0tOo8n2xzJ7YOQpV1GIKHhs3p+F40ThI8/DoYWbYKQ==
+camelize-ts@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camelize-ts/-/camelize-ts-3.0.0.tgz#b9a7b4ff802464dc3d6475637a64a9742ad3db09"
+  integrity sha512-cgRwKKavoDKLTjO4FQTs3dRBePZp/2Y9Xpud0FhuCOTE86M2cniKN4CCXgRnsyXNMmQMifVHcv6SPaMtTx6ofQ==
 
 cluster-key-slot@^1.1.0:
   version "1.1.2"
@@ -275,11 +259,6 @@ debug@^4.3.4:
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
   dependencies:
     ms "^2.1.3"
-
-decode-uri-component@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz"
-  integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
 deep-diff@^1.0.2:
   version "1.0.2"
@@ -419,11 +398,6 @@ fast-json-stable-stringify@^2.0.0:
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-filter-obj@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz"
-  integrity sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==
-
 finalhandler@1.3.1:
   version "1.3.1"
   resolved "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz"
@@ -436,11 +410,6 @@ finalhandler@1.3.1:
     parseurl "~1.3.3"
     statuses "2.0.1"
     unpipe "~1.0.0"
-
-follow-redirects@^1.14.8:
-  version "1.15.9"
-  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz"
-  integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -559,11 +528,6 @@ ipaddr.js@1.9.1:
   resolved "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz"
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
-js-sha256@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.npmjs.org/js-sha256/-/js-sha256-0.9.0.tgz"
-  integrity sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==
-
 "js-tokens@^3.0.0 || ^4.0.0":
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -638,14 +602,6 @@ jws@^4.0.0:
     jwa "^2.0.0"
     safe-buffer "^5.0.1"
 
-keycloak-js@^17.0.1:
-  version "17.0.1"
-  resolved "https://registry.npmjs.org/keycloak-js/-/keycloak-js-17.0.1.tgz"
-  integrity sha512-mbLBSoogCBX5VYeKCdEz8BaRWVL9twzSqArRU3Mo3Z7vEO1mghGZJ5IzREfiMEi7kTUZtk5i9mu+Yc0koGkK6g==
-  dependencies:
-    base64-js "^1.5.1"
-    js-sha256 "^0.9.0"
-
 lambda-api-router@^1.0.6:
   version "1.0.6"
   resolved "https://registry.npmjs.org/lambda-api-router/-/lambda-api-router-1.0.6.tgz"
@@ -700,9 +656,9 @@ lodash.once@^4.0.0:
   resolved "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz"
   integrity sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==
 
-lodash@^4.17.15, lodash@^4.17.20, lodash@^4.17.21:
+lodash@^4.17.15, lodash@^4.17.20:
   version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.1.0, loose-envify@^1.4.0:
@@ -839,16 +795,6 @@ qs@6.13.0:
   integrity sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==
   dependencies:
     side-channel "^1.0.6"
-
-query-string@^7.0.1:
-  version "7.1.3"
-  resolved "https://registry.npmjs.org/query-string/-/query-string-7.1.3.tgz"
-  integrity sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==
-  dependencies:
-    decode-uri-component "^0.2.2"
-    filter-obj "^1.1.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
 
 range-parser@~1.2.1:
   version "1.2.1"
@@ -1006,11 +952,6 @@ side-channel@^1.0.6:
     get-intrinsic "^1.2.4"
     object-inspect "^1.13.1"
 
-split-on-first@^1.0.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz"
-  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
-
 standard-as-callback@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/standard-as-callback/-/standard-as-callback-2.1.0.tgz"
@@ -1020,11 +961,6 @@ statuses@2.0.1:
   version "2.0.1"
   resolved "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz"
   integrity sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==
-
-strict-uri-encode@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz"
-  integrity sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==
 
 toidentifier@1.0.1:
   version "1.0.1"
@@ -1051,15 +987,15 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-url-join@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz"
-  integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
+url-join@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/url-join/-/url-join-5.0.0.tgz#c2f1e5cbd95fa91082a93b58a1f42fecb4bdbcf1"
+  integrity sha512-n2huDr9h9yzd6exQVnH/jU5mr+Pfx08LRXXZhkLLetAMESRj+anQsTAh940iMrIetKAmry9coFuZQ2jY8/p3WA==
 
-url-template@^2.0.8:
-  version "2.0.8"
-  resolved "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz"
-  integrity sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==
+url-template@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/url-template/-/url-template-3.1.1.tgz#c220d5f3f793d28b0de341002112879cc8a43905"
+  integrity sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA==
 
 utils-merge@1.0.1:
   version "1.0.1"

--- a/lambda/jest.config.js
+++ b/lambda/jest.config.js
@@ -1,12 +1,22 @@
 module.exports = {
   roots: ['<rootDir>'],
+  preset: 'ts-jest/presets/js-with-ts',
   testMatch: ['**/?(*.)+(spec|test).+(ts|tsx|js)'],
   transform: {
-    '^.+\\.(ts|tsx)$': 'ts-jest',
+    // IMPORTANT: js is here intentionally to transform js files with ES Module syntax. The overriding config file allows js.
+    '^.+\\.(ts|tsx|js)$': [
+      'ts-jest', // Transformer
+      {
+        tsconfig: 'tsconfig.jest.json',
+      },
+    ],
   },
   setupFilesAfterEnv: ['./__tests__/jest.setup.js'],
   testSequencer: './testSequencer.js',
   testPathIgnorePatterns: ['/node_modules/', '/build/'],
+  // This should not work, but it does. We dont even use pnpm but tests wont run without it.
+  // transformIgnorePatterns: ['/node_modules/.pnpm/(?!@keycloak)'],
+  transformIgnorePatterns: ['/node_modules/(?!(@keycloak|url-join|url-template|camelize-ts)/)'],
   moduleNameMapper: {
     '^@app/(.*)$': '<rootDir>/../app/$1',
     '^@lambda-app/(.*)$': '<rootDir>/app/src/$1',

--- a/lambda/jest.config.js
+++ b/lambda/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   transform: {
     // IMPORTANT: js is here intentionally to transform js files with ES Module syntax. The overriding config file allows js.
     '^.+\\.(ts|tsx|js)$': [
-      'ts-jest', // Transformer
+      'ts-jest',
       {
         tsconfig: 'tsconfig.jest.json',
       },
@@ -14,8 +14,6 @@ module.exports = {
   setupFilesAfterEnv: ['./__tests__/jest.setup.js'],
   testSequencer: './testSequencer.js',
   testPathIgnorePatterns: ['/node_modules/', '/build/'],
-  // This should not work, but it does. We dont even use pnpm but tests wont run without it.
-  // transformIgnorePatterns: ['/node_modules/.pnpm/(?!@keycloak)'],
   transformIgnorePatterns: ['/node_modules/(?!(@keycloak|url-join|url-template|camelize-ts)/)'],
   moduleNameMapper: {
     '^@app/(.*)$': '<rootDir>/../app/$1',

--- a/lambda/tsconfig.jest.json
+++ b/lambda/tsconfig.jest.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true
+  }
+}

--- a/localserver/bunfig.toml
+++ b/localserver/bunfig.toml
@@ -1,0 +1,1 @@
+preload = ["./reflect-metadata-import.ts"]

--- a/localserver/package.json
+++ b/localserver/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "author": "SSO Team",
   "scripts": {
-    "dev": "nodemon --trace-warnings",
+    "dev": "bun --hot server.ts",
     "migrate-db": "nodemon --config nodemon-db.json"
   },
   "devDependencies": {

--- a/localserver/package.json
+++ b/localserver/package.json
@@ -26,14 +26,6 @@
   "resolutions": {
     "minimist": ">=1.2.6"
   },
-  "nodemonConfig": {
-    "watch": [
-      "./",
-      "../lambda"
-    ],
-    "ext": "ts,json",
-    "exec": "ts-node -r tsconfig-paths/register -r dotenv/config ./server.ts"
-  },
   "dependencies": {
     "axios": "^1.7.7",
     "cors": "^2.8.5"

--- a/localserver/reflect-metadata-import.ts
+++ b/localserver/reflect-metadata-import.ts
@@ -1,0 +1,1 @@
+import 'reflect-metadata';


### PR DESCRIPTION
Bump keycloak lib to match our keycloak version, and fix local dev environment. The new keycloak-admin-client version's ESM syntax was not compatible with ts-node which we use to develop locally, so I switched it out to use bun. There are many alternatives, but note that anything built on top of esbuild (like `tsx`) does not support "emitDecoratorMetadata" in the tsconfig which we require. This is because [esbuild won't do type checking](https://esbuild.github.io/content-types/#typescript).

Bun seems like a great choice though, it's super fast on the hot reloading and is [committed to supporting cjs long term](https://bun.sh/blog/commonjs-is-not-going-away). Also has some out of the box features like automatic env file loading, hot reloading without nodemon as a requirement, and ts support. We can also use it as a package manager instead of yarn if we like it, but I left the yarn lockfiles for now.

Bun is also asdf supported so can just re-run the asdf install steps in the dev guide to get it installed.