### PR TITLE
chore: svc acct username

### DIFF
--- a/lambda/app/src/keycloak/installation/oidc.ts
+++ b/lambda/app/src/keycloak/installation/oidc.ts
@@ -34,6 +34,10 @@ export const generateInstallation = async (data: {
 
   if (['service-account', 'both'].includes(authType)) {
     rep['token-url'] = `${authServerUrl}/realms/${realm.realm}/protocol/openid-connect/token`;
+    rep['service-account'] = {
+      username: `service-account-${client.clientId}`,
+      description: "The service account's username for managing its roles through the CSS API.",
+    };
   }
 
   if (['browser-login', 'both'].includes(authType))


### PR DESCRIPTION
add information on the service account username to json payload for relevant client types