### PR TITLE
chore: large download

### DIFF
--- a/app/page-partials/my-dashboard/IntegrationInfoTabs/LogsPanel.tsx
+++ b/app/page-partials/my-dashboard/IntegrationInfoTabs/LogsPanel.tsx
@@ -99,11 +99,10 @@ interface Props {
  * @param filename Name to give to the downloaded file
  * @param dataObjToWrite The data to include in the file
  */
-const saveTemplateAsFile = (filename: string, dataObjToWrite: any) => {
-  const blob = new Blob([JSON.stringify(dataObjToWrite)], { type: 'text/json' });
+const saveTemplateAsFile = (filename: string, dataObjToWrite: Blob) => {
   const link = document.createElement('a');
   link.download = filename;
-  link.href = window.URL.createObjectURL(blob);
+  link.href = window.URL.createObjectURL(dataObjToWrite);
   link.dataset.downloadurl = ['text/json', link.download, link.href].join(':');
 
   const evt = new MouseEvent('click', {
@@ -226,7 +225,7 @@ const LogsPanel = ({ integration, alert }: Props) => {
           variant: 'danger',
           fadeOut: 10000,
           closable: true,
-          content: (await err.response.data.text()) ?? err?.response?.data?.message ?? 'Error fetching logs.',
+          content: 'Error fetching logs.',
         });
       } else {
         alert.show({
@@ -235,10 +234,9 @@ const LogsPanel = ({ integration, alert }: Props) => {
           closable: true,
           content: result?.message ?? 'Downloaded logs.',
         });
-        const resultJSON = await result.text();
         saveTemplateAsFile(
           `${integration.clientId}-${fromDate.toLocaleString()}-${toDate.toLocaleString()}.json`,
-          JSON.parse(resultJSON),
+          result.data,
         );
         surveyContext?.setShowSurvey(true, 'downloadLogs');
       }

--- a/app/services/grafana.ts
+++ b/app/services/grafana.ts
@@ -1,4 +1,4 @@
-import { AxiosProgressEvent } from 'axios';
+import { AxiosError, AxiosProgressEvent } from 'axios';
 import { instance } from './axios';
 
 export const getMetrics = async (id: number, env: string, fromDate?: string, toDate?: string) => {
@@ -21,17 +21,16 @@ export const getLogs = async (
   toDate: Date,
   onProgress: (progressEvent: AxiosProgressEvent) => void,
   controller?: AbortController,
-) => {
+): Promise<[{ data: Blob; message: string }, null] | [null, AxiosError<any>]> => {
   try {
     const result = await instance({
       url: `requests/${id}/logs?env=${env}&start=${fromDate}&end=${toDate}`,
       responseType: 'blob',
       onDownloadProgress: onProgress,
       signal: controller?.signal,
-    }).then((res: any) => res?.data);
-
+    }).then((res) => ({ data: res?.data, message: res?.headers['x-message'] }));
     return [result, null];
   } catch (err) {
-    return [null, err];
+    return [null, err as AxiosError<any>];
   }
 };

--- a/lambda/app/src/keycloak/installation/oidc.ts
+++ b/lambda/app/src/keycloak/installation/oidc.ts
@@ -34,6 +34,10 @@ export const generateInstallation = async (data: {
 
   if (['service-account', 'both'].includes(authType)) {
     rep['token-url'] = `${authServerUrl}/realms/${realm.realm}/protocol/openid-connect/token`;
+    rep['service-account'] = {
+      username: `service-account-${client.clientId}`,
+      description: "The service account's username for managing its roles through the CSS API.",
+    };
   }
 
   if (['browser-login', 'both'].includes(authType))

--- a/lambda/app/src/main.ts
+++ b/lambda/app/src/main.ts
@@ -28,6 +28,7 @@ router.use(
     origin: process.env.LOCAL_DEV === 'true' ? '*' : 'https://bcgov.github.io',
     methods: ['OPTIONS', 'GET', 'POST', 'PUT', 'DELETE'],
     allowedHeaders: ['Content-Type', 'Authorization'],
+    exposedHeaders: ['X-Message'],
     credentials: true,
   }),
 );

--- a/lambda/app/src/routes.ts
+++ b/lambda/app/src/routes.ts
@@ -318,6 +318,7 @@ export const setRoutes = (app: any) => {
           req.session.idir_userid,
         );
         if (status === 200) {
+          res.setHeader('X-Message', message);
           res.setHeader('Content-Length', JSON.stringify(data).length);
           res.setHeader('Content-Type', 'application/json');
           res.setHeader('Content-Disposition', `attachment`);

--- a/lambda/css-api/src/routes.ts
+++ b/lambda/css-api/src/routes.ts
@@ -187,7 +187,11 @@ export const setRoutes = (app: any) => {
         description: 'Forbidden',
         schema: { message: 'string' }
       }
-      #swagger.responses[500] = {
+      #swagger.responses[429] = {
+        description: 'Too Many Requests. Will be rate limited after 10 requests for the same integration and environment per hour.',
+        schema: { message: 'string' }
+      }
+      #swagger.responses[500,504] = {
         description: 'Server Error',
         schema: { message: 'string' }
       }
@@ -200,7 +204,7 @@ export const setRoutes = (app: any) => {
         return res.status(403).json({ message: 'forbidden' });
       }
       const { status, message, data } = await fetchLogs(environment, int.clientId, int.id, start, end);
-      if (status === 200) res.status(status).send({ data });
+      if (status === 200) res.status(status).send({ data, message });
       else res.status(status).send({ message });
     } catch (err) {
       handleError(res, err);

--- a/lambda/css-api/src/swagger.js
+++ b/lambda/css-api/src/swagger.js
@@ -78,12 +78,15 @@ const doc = {
         name: 'client-role',
         composite: false,
       },
-      logsResponse: [
-        {
-          '@timestamp': 'string',
-          message: 'string',
-        },
-      ],
+      logsResponse: {
+        data: [
+          {
+            '@timestamp': 'string',
+            message: 'string',
+          },
+        ],
+        message: 'string',
+      },
       compositeRoleRequest: {
         $name: 'composite-role',
       },

--- a/localserver/express-server.ts
+++ b/localserver/express-server.ts
@@ -21,7 +21,7 @@ const initExpresss = async () => {
   expressServer.use(bodyParser.json());
   expressServer.use(bodyParser.urlencoded({ extended: false }));
   expressServer.use(cookieParser());
-  expressServer.use(cors({ origin: 'http://localhost:3000', credentials: true }));
+  expressServer.use(cors({ origin: 'http://localhost:3000', credentials: true, exposedHeaders: ['X-Message'] }));
 
   expressServer.disable('x-powered-by');
   expressServer.set('trust proxy', 1);

--- a/terraform/api-gateway.tf
+++ b/terraform/api-gateway.tf
@@ -5,6 +5,8 @@
 resource "aws_api_gateway_rest_api" "sso_backend" {
   name        = "SSOApi"
   description = "Terraform Serverless Application Example"
+  # Compress for 25Kb and larger responses
+  minimum_compression_size = 25000
 
   endpoint_configuration {
     types = ["REGIONAL"]


### PR DESCRIPTION
Two improvements for large log downloads:

- Compression at the API Gateway for responses larger than 25KB
- Send the message for "all logs retrieved" or size limit reached in the header "x-message". This prevents having to parse out the JSON blob just to read the message on the client, so the logs blob can be attached to file download directly.

Also included the message in the css-api response, which has useful information if query params are incorrect, e.g malformed dates.