### PR TITLE
chore: deletion emails

### DIFF
--- a/app/page-partials/my-dashboard/IntegrationInfoTabs/LogsPanel.tsx
+++ b/app/page-partials/my-dashboard/IntegrationInfoTabs/LogsPanel.tsx
@@ -173,6 +173,8 @@ const LogsPanel = ({ integration, alert }: Props) => {
   };
 
   const handleFileProgress = (progressEvent: AxiosProgressEvent) => {
+    // Ignore progress indicator if unsupported in browser. Some browsers ignore content-length for zipped responses.
+    if (progressEvent.total === undefined || progressEvent.loaded === undefined) return;
     const percentComplete = Math.floor((progressEvent.loaded / Number(progressEvent.total)) * 100);
     if (percentComplete !== fileProgress) {
       setFileProgress(percentComplete);

--- a/lambda/__tests__/11.remove-inactive-users.test.ts
+++ b/lambda/__tests__/11.remove-inactive-users.test.ts
@@ -44,7 +44,7 @@ jest.mock('../app/src/keycloak/client', () => {
   };
 });
 
-describe.skip('users and teams', () => {
+describe('users and teams', () => {
   try {
     beforeAll(async () => {
       jest.clearAllMocks();
@@ -168,11 +168,10 @@ describe('Deleted user emails', () => {
 
   beforeEach(async () => {
     await models.user.create({ idirUserid: SSO_TEAM_IDIR_USER, idirEmail: SSO_TEAM_IDIR_EMAIL });
-    // await models.user.create({ idirUserid: TEAM_ADMIN_IDIR_USERID_01, idirEmail: TEAM_ADMIN_IDIR_EMAIL_01 });
     createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
   });
 
-  it.skip('Sends one email notification when a deleted user owns an integration directly', async () => {
+  it('Sends one email notification when a deleted user owns an integration directly', async () => {
     const emailList = createMockSendEmail();
     const request = await buildIntegration({
       projectName: 'Delete Inactive Users',
@@ -190,7 +189,7 @@ describe('Deleted user emails', () => {
     expect(deleteInactiveIntegrationEmails.length).toBe(0);
   });
 
-  it.skip('Sends one email notification when a deleted user with no roles is the admin of the owning team', async () => {
+  it('Sends one email notification when a deleted user with no roles is the admin of the owning team', async () => {
     const emailList = createMockSendEmail();
     const adminTeam = await createTeam({
       name: 'test_team',
@@ -220,7 +219,7 @@ describe('Deleted user emails', () => {
     expect(orphanedIntegrationEmails.length).toBe(0);
   });
 
-  it.skip('Sends one email notification when a deleted user with roles is the admin of the owning team', async () => {
+  it('Sends one email notification when a deleted user with roles is the admin of the owning team', async () => {
     const emailList = createMockSendEmail();
     const adminTeam = await createTeam({
       name: 'test_team',

--- a/lambda/app/src/controllers/user.ts
+++ b/lambda/app/src/controllers/user.ts
@@ -187,7 +187,7 @@ export const deleteStaleUsers = async (
           },
           raw: true,
         });
-        if (integration?.teamId) {
+        if (integration?.teamId && !integration.archived) {
           const userEmails = await getAllEmailsOfTeam(integration.teamId);
           let isTeamAdmin = false;
           userEmails.map((u: any) => {
@@ -254,7 +254,7 @@ export const deleteStaleUsers = async (
               rqst.userId = ssoUser.id;
               await rqst.save();
               // Notification was already sent above if roles were included.
-              if (!userHadRoles) {
+              if (!userHadRoles && !rqst.archived) {
                 await sendTemplate(EMAILS.DELETE_INACTIVE_IDIR_USER, {
                   teamId: rqst.teamId,
                   username: user.attributes.idir_username || user.username,


### PR DESCRIPTION
- Check for undefined on progress event, some browsers are not reading in the Content-Length header for zipped responses
- skip the deletion emails if the integrations are archived