### PR TITLE
fix: sequalize connections

### DIFF
--- a/lambda/jest.config.js
+++ b/lambda/jest.config.js
@@ -20,6 +20,7 @@ module.exports = {
     '^@lambda-app/(.*)$': '<rootDir>/app/src/$1',
     '^@lambda-shared/(.*)$': '<rootDir>/shared/$1',
     '^@lambda-css-api/(.*)$': '<rootDir>/css-api/src/$1',
+    '^@request-queue/(.*)$': '<rootDir>/request-queue/src/$1',
   },
   verbose: true,
   coverageReporters: ['json', 'html'],

--- a/lambda/request-queue/src/db.ts
+++ b/lambda/request-queue/src/db.ts
@@ -1,0 +1,60 @@
+import { Sequelize, DataTypes } from 'sequelize';
+import configs from '@lambda-shared/sequelize/config/config';
+import Event from '@lambda-shared/sequelize/models/Event';
+import Request from '@lambda-shared/sequelize/models/Request';
+import Team from '@lambda-shared/sequelize/models/Team';
+import User from '@lambda-shared/sequelize/models/User';
+import Survey from '@lambda-shared/sequelize/models/Survey';
+import UserTeam from '@lambda-shared/sequelize/models/UserTeam';
+import RequestQueue from '@lambda-shared/sequelize/models/RequestQueue';
+import RequestRole from '@lambda-shared/sequelize/models/RequestRole';
+import BcscClient from '@lambda-shared/sequelize/models/BcscClient';
+
+const env = process.env.NODE_ENV || 'development';
+
+// See https://sequelize.org/docs/v6/other-topics/aws-lambda/#tldr
+const config = {
+  ...configs[env],
+  pool: {
+    max: 2,
+    min: 0,
+    idle: 0,
+    acquire: 3000,
+    // Should match timeout in the lambda configuration. See terraform/lambda-request-queue.tf.
+    evict: 45,
+  },
+};
+
+export const models: any = {};
+export const modelNames: string[] = [];
+export let sequelize = null;
+
+export const loadSequelize = async () => {
+  // Use the shared sequelize env for local development and testing. Use custom configuration in lambda runtimes.
+  if (env === 'development') {
+    ({ sequelize } = await import('@lambda-shared/sequelize/models/models'));
+  } else if (config.databaseUrl) {
+    sequelize = new Sequelize(config.databaseUrl, config);
+  } else if (config.use_env_variable && process.env[config.use_env_variable]) {
+    sequelize = new Sequelize(process.env[config.use_env_variable], config);
+  } else {
+    sequelize = new Sequelize(config.database, config.username, config.password, config);
+  }
+
+  console.log('sequelize initialized', !!sequelize);
+
+  [Event, Request, Team, User, UserTeam, Survey, RequestQueue, RequestRole, BcscClient].forEach((init) => {
+    const model = init(sequelize, DataTypes);
+    models[model.name] = model;
+    modelNames.push(model.name);
+  });
+
+  Object.keys(models).forEach((modelName) => {
+    if (models[modelName]?.options.associate) {
+      models[modelName].options.associate(models);
+    }
+  });
+
+  await sequelize.authenticate();
+  return sequelize;
+};

--- a/lambda/request-queue/src/db.ts
+++ b/lambda/request-queue/src/db.ts
@@ -27,9 +27,9 @@ const config = {
 
 export const models: any = {};
 export const modelNames: string[] = [];
-export let sequelize = null;
 
 export const loadSequelize = async () => {
+  let sequelize = null;
   // Use the shared sequelize env for local development and testing. Use custom configuration in lambda runtimes.
   if (env === 'development') {
     ({ sequelize } = await import('@lambda-shared/sequelize/models/models'));

--- a/lambda/request-queue/src/main.ts
+++ b/lambda/request-queue/src/main.ts
@@ -27,6 +27,9 @@ export const handler = async () => {
       sequelize = await loadSequelize();
     } else {
       sequelize.connectionManager.initPools();
+      if (sequelize.connectionManager.hasOwnProperty('getConnection')) {
+        delete sequelize.connectionManager.getConnection;
+      }
     }
     const allPromises: Promise<any>[] = [];
     const requestQueue = await models.requestQueue.findAll();

--- a/lambda/request-queue/src/main.ts
+++ b/lambda/request-queue/src/main.ts
@@ -22,7 +22,7 @@ export const sendRcNotification = async (message) => {
 export const handler = async () => {
   try {
     if (!sequelize) {
-      await loadSequelize();
+      loadSequelize();
     } else {
       sequelize.connectionManager.initPools();
     }

--- a/lambda/shared/sequelize/models/models.ts
+++ b/lambda/shared/sequelize/models/models.ts
@@ -17,26 +17,30 @@ export const models: any = {};
 export const modelNames: string[] = [];
 export let sequelize;
 
-if (config.databaseUrl) {
-  sequelize = new Sequelize(config.databaseUrl, config);
-} else if (config.use_env_variable && process.env[config.use_env_variable]) {
-  sequelize = new Sequelize(process.env[config.use_env_variable], config);
-} else {
-  sequelize = new Sequelize(config.database, config.username, config.password, config);
-}
-
-console.log('sequelize initialized', !!sequelize);
-
-[Event, Request, Team, User, UserTeam, Survey, RequestQueue, RequestRole, BcscClient].forEach((init) => {
-  const model = init(sequelize, DataTypes);
-  models[model.name] = model;
-  modelNames.push(model.name);
-});
-
-Object.keys(models).forEach((modelName) => {
-  if (models[modelName]?.options.associate) {
-    models[modelName].options.associate(models);
+export const loadSequelize = () => {
+  if (config.databaseUrl) {
+    sequelize = new Sequelize(config.databaseUrl, config);
+  } else if (config.use_env_variable && process.env[config.use_env_variable]) {
+    sequelize = new Sequelize(process.env[config.use_env_variable], config);
+  } else {
+    sequelize = new Sequelize(config.database, config.username, config.password, config);
   }
-});
+
+  console.log('sequelize initialized', !!sequelize);
+
+  [Event, Request, Team, User, UserTeam, Survey, RequestQueue, RequestRole, BcscClient].forEach((init) => {
+    const model = init(sequelize, DataTypes);
+    models[model.name] = model;
+    modelNames.push(model.name);
+  });
+
+  Object.keys(models).forEach((modelName) => {
+    if (models[modelName]?.options.associate) {
+      models[modelName].options.associate(models);
+    }
+  });
+};
+
+loadSequelize();
 
 export default { models, modelNames, sequelize };

--- a/lambda/shared/sequelize/models/models.ts
+++ b/lambda/shared/sequelize/models/models.ts
@@ -17,30 +17,26 @@ export const models: any = {};
 export const modelNames: string[] = [];
 export let sequelize;
 
-export const loadSequelize = () => {
-  if (config.databaseUrl) {
-    sequelize = new Sequelize(config.databaseUrl, config);
-  } else if (config.use_env_variable && process.env[config.use_env_variable]) {
-    sequelize = new Sequelize(process.env[config.use_env_variable], config);
-  } else {
-    sequelize = new Sequelize(config.database, config.username, config.password, config);
+if (config.databaseUrl) {
+  sequelize = new Sequelize(config.databaseUrl, config);
+} else if (config.use_env_variable && process.env[config.use_env_variable]) {
+  sequelize = new Sequelize(process.env[config.use_env_variable], config);
+} else {
+  sequelize = new Sequelize(config.database, config.username, config.password, config);
+}
+
+console.log('sequelize initialized', !!sequelize);
+
+[Event, Request, Team, User, UserTeam, Survey, RequestQueue, RequestRole, BcscClient].forEach((init) => {
+  const model = init(sequelize, DataTypes);
+  models[model.name] = model;
+  modelNames.push(model.name);
+});
+
+Object.keys(models).forEach((modelName) => {
+  if (models[modelName]?.options.associate) {
+    models[modelName].options.associate(models);
   }
-
-  console.log('sequelize initialized', !!sequelize);
-
-  [Event, Request, Team, User, UserTeam, Survey, RequestQueue, RequestRole, BcscClient].forEach((init) => {
-    const model = init(sequelize, DataTypes);
-    models[model.name] = model;
-    modelNames.push(model.name);
-  });
-
-  Object.keys(models).forEach((modelName) => {
-    if (models[modelName]?.options.associate) {
-      models[modelName].options.associate(models);
-    }
-  });
-};
-
-loadSequelize();
+});
 
 export default { models, modelNames, sequelize };


### PR DESCRIPTION
Customizing the sequelize connection for the request queue. See [here](https://sequelize.org/docs/v6/other-topics/aws-lambda/#tldr) for reference on setting up sequelize and and lambda functions, they are recommending to avoid pooling across invocations.

I added this only for the request-queue lambda, since it runs in a single invocations every 5 minutes there aren't multiple containers in parallel creating connections. If using the same thing in the API lambda functions, we should first add [AWS RDS Proxy](https://aws.amazon.com/rds/proxy/) to make connections to the DB cheaper to establish, since they will have multiple running containers at once.