### PR TITLE
chore: old module

### DIFF
--- a/terraform/env-resources.tf_prod
+++ b/terraform/env-resources.tf_prod
@@ -3,11 +3,6 @@ module "s3_keycloak_v2" {
   bucket_name = "xgr00q-prod-keycloak"
 }
 
-module "s3_sso_loki" {
-  source      = "./s3-bucket"
-  bucket_name = "xgr00q-prod-sso-loki"
-}
-
 module "s3_sysdig" {
   source      = "./s3-bucket"
   bucket_name = "xgr00q-prod-sysdig"


### PR DESCRIPTION
Remove old module from terraform, in the env-resources.tf_prod file there is an s3 reference with the same bucket name I used for loki. This overrode some of its configuration on production deploy.

The bucket was being tracked in both sets of terraform state. I have removed this form the sso-requests state so that it no longer tracks it and won't try to remove it.