### PR TITLE
feat: format client name and jwks uri for bcsc integrations

### DIFF
--- a/lambda/app/src/bcsc/client.ts
+++ b/lambda/app/src/bcsc/client.ts
@@ -79,7 +79,7 @@ export const createBCSCClient = async (data: BCSCClientParameters, integration: 
 export const updateBCSCClient = async (bcscClient: BCSCClientParameters, integration: IntegrationData) => {
   const { kcBaseUrl, bcscBaseUrl } = getBCSCEnvVars(bcscClient.environment);
   const contacts = await getBCSCContacts(integration);
-  const jwksUri = `${kcBaseUrl}/realms/standard/protocol/openid-connect/certs`;
+  const jwksUri = `${kcBaseUrl}/auth/realms/standard/protocol/openid-connect/certs`;
   const requiredScopes = await getRequiredBCSCScopes(integration.bcscAttributes);
 
   const result = await axios.put(

--- a/lambda/app/src/bcsc/client.ts
+++ b/lambda/app/src/bcsc/client.ts
@@ -53,7 +53,7 @@ export const createBCSCClient = async (data: BCSCClientParameters, integration: 
   const result = await axios.post(
     `${bcscBaseUrl}/oauth2/register`,
     {
-      client_name: `${data.clientName}-${data.environment}`,
+      client_name: data.clientName,
       client_uri: integration[`${data.environment}HomePageUri`],
       redirect_uris: [`${kcBaseUrl}/auth/realms/standard/broker/${integration.clientId}/endpoint`],
       scope: requiredScopes.join(' '),
@@ -85,7 +85,7 @@ export const updateBCSCClient = async (bcscClient: BCSCClientParameters, integra
   const result = await axios.put(
     `${bcscBaseUrl}/oauth2/register/${bcscClient.clientId}`,
     {
-      client_name: `${bcscClient.clientName}-${bcscClient.environment}`,
+      client_name: bcscClient.clientName,
       client_uri: integration[`${bcscClient.environment}HomePageUri`],
       redirect_uris: [`${kcBaseUrl}/auth/realms/standard/broker/${integration.clientId}/endpoint`],
       scope: requiredScopes.join(' '),

--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -247,7 +247,7 @@ export const createBCSCIntegration = async (env: string, integration: Integratio
   let bcscClientSecret = bcscClient?.clientSecret;
   let bcscClientId = bcscClient?.clientId;
   if (!bcscClient) {
-    const bcscClientName = `${integration.projectName}-${integration.id}`;
+    const bcscClientName = `${env !== 'prod' ? integration.projectName + '-' + env : integration.projectName}`;
     const clientResponse: any = await createBCSCClient(
       {
         clientName: bcscClientName,


### PR DESCRIPTION
1. Only dev and test client names contain env suffix
2. jwks URI now includes `/auth`