### PR TITLE
feat: allow privacy zone updates for bcsc

### DIFF
--- a/app/jest/form.test.tsx
+++ b/app/jest/form.test.tsx
@@ -648,7 +648,7 @@ describe('BC Services Card IDP and dependencies', () => {
     fireEvent.change(uriInput, { target: { value: 'https://valid-uri' } });
   });
 
-  it('should keep BCSC attributes editable if not approved yet', async () => {
+  it('should keep BCSC privacy zone and attributes editable if not approved yet', async () => {
     const { getByText } = setUpRender({
       id: 0,
       serviceType: 'gold',
@@ -662,10 +662,10 @@ describe('BC Services Card IDP and dependencies', () => {
     });
     fireEvent.click(sandbox.basicInfoBox);
     const bcscCheckbox = getByText('BC Services Card')?.parentElement?.querySelector("input[type='checkbox']");
-    expect(bcscCheckbox).toBeDisabled();
+    expect(bcscCheckbox).not.toBeDisabled();
     expect(bcscCheckbox).toBeChecked();
     const bcscPrivacyZoneDropDown = screen.getByTestId('bcsc-privacy-zone') as HTMLElement;
-    expect(bcscPrivacyZoneDropDown?.querySelector("input[type='text']")).toBeDisabled();
+    expect(bcscPrivacyZoneDropDown?.querySelector("input[type='text']")).not.toBeDisabled();
 
     const bcscAttributesDropDown = screen.getByTestId('bcsc-attributes') as HTMLElement;
     const attributesInput = bcscAttributesDropDown.lastChild;

--- a/app/schemas-ui/ui-gold.ts
+++ b/app/schemas-ui/ui-gold.ts
@@ -52,6 +52,7 @@ const getUISchema = ({ integration, formData, isAdmin }: Props) => {
         if (checkGithubGroup(idp)) {
           idpDisabled.push('githubpublic', 'githubbcgov');
         }
+        if (idp === 'bcservicescard' && bcServicesCardApproved) idpDisabled.push('bcservicescard');
       });
     }
 

--- a/app/schemas-ui/ui-gold.ts
+++ b/app/schemas-ui/ui-gold.ts
@@ -37,7 +37,6 @@ const getUISchema = ({ integration, formData, isAdmin }: Props) => {
   } = integration || {};
   const isNew = isNil(id);
   const isApplied = status === 'applied';
-  const disableBcscUpdateApplied = integration?.devIdps?.includes('bcservicescard') && status !== 'draft';
   const disableBcscUpdateApproved = integration?.devIdps?.includes('bcservicescard') && bcServicesCardApproved;
 
   const envDisabled = isApplied ? environments?.concat() || [] : ['dev'];
@@ -53,8 +52,6 @@ const getUISchema = ({ integration, formData, isAdmin }: Props) => {
         if (checkGithubGroup(idp)) {
           idpDisabled.push('githubpublic', 'githubbcgov');
         }
-
-        if (idp === 'bcservicescard') idpDisabled.push('bcservicescard');
       });
     }
 
@@ -76,7 +73,7 @@ const getUISchema = ({ integration, formData, isAdmin }: Props) => {
     bcscPrivacyZone: {
       'ui:widget': BcscPrivacyZoneWidget,
       classNames: 'short-field-string',
-      'ui:disabled': disableBcscUpdateApplied,
+      'ui:disabled': disableBcscUpdateApproved,
     },
     bcscAttributes: {
       'ui:widget': BcscAttributesWidget,

--- a/lambda/__tests__/21.requests-validations.test.ts
+++ b/lambda/__tests__/21.requests-validations.test.ts
@@ -231,7 +231,6 @@ describe('integration validations', () => {
         {
           ...getUpdateIntegrationData({ integration: bcServicesCardIntegration }),
           bcServicesCardApproved: true,
-          bcscPrivacyZone: 'zone2',
         },
         true,
       );

--- a/lambda/__tests__/24.bcsc-api.test.ts
+++ b/lambda/__tests__/24.bcsc-api.test.ts
@@ -51,14 +51,14 @@ describe('BCSC API Callouts', () => {
     expect(axiosDataArg.claims.includes('sub')).toBeTruthy();
   });
 
-  it('Excludes privacy zone when updating a BCSC client', async () => {
+  it('Includes privacy zone when updating a BCSC client', async () => {
     await updateBCSCClient(bcscClient, bcscData);
     expect(axios.put).toHaveBeenCalledTimes(1);
     const [, axiosDataArg] = (axios.put as jest.Mock).mock.calls[0];
     const bcscJSONKeys = Object.keys(axiosDataArg);
 
     expect(bcscJSONKeys.includes('claims')).toBeTruthy();
-    expect(bcscJSONKeys.includes('privacy_zone_uri')).toBeFalsy();
+    expect(bcscJSONKeys.includes('privacy_zone_uri')).toBeTruthy();
   });
 
   it('Fetches the privacy zone uri for the provided environment', async () => {

--- a/lambda/app/src/bcsc/client.ts
+++ b/lambda/app/src/bcsc/client.ts
@@ -97,6 +97,7 @@ export const updateBCSCClient = async (bcscClient: BCSCClientParameters, integra
       jwks_uri: jwksUri,
       client_id: bcscClient.clientId,
       registration_access_token: bcscClient.registrationAccessToken,
+      privacy_zone_uri: integration.bcscPrivacyZone,
     },
     {
       headers: {

--- a/lambda/app/src/keycloak/integration.ts
+++ b/lambda/app/src/keycloak/integration.ts
@@ -165,7 +165,7 @@ export const keycloakClient = async (
 
     if (usesBcServicesCard(integration)) {
       await createBCSCIntegration(environment, integration, integration.userId);
-    } else if (await usesBCSCIntegration(bcscClientDetails, integration.clientId)) {
+    } else if (bcscClientDetails && (await usesBCSCIntegration(bcscClientDetails, integration.clientId))) {
       await deleteBCSCIntegration(bcscClientDetails, integration.clientId);
     }
 

--- a/lambda/app/src/queries/bcsc-client.ts
+++ b/lambda/app/src/queries/bcsc-client.ts
@@ -1,0 +1,10 @@
+import { models } from '@lambda-shared/sequelize/models/models';
+
+export const getByRequestId = async (integrationId: number, environment: string) => {
+  return await models.bcscClient.findOne({
+    where: {
+      requestId: integrationId,
+      environment,
+    },
+  });
+};


### PR DESCRIPTION
BC Services Card Updates:

1. Allow privacy zone update before approval
2. Allow removal of bcsc idp before approval