### PR TITLE
chore: permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ assumes one available VPC exists with available subnets in two zones. To set the
 The lambda functions are written in typescript, and to compile and bundle them you can run `make lambda-all` from the lambda directory.
 Once they are compiled, from the [terraform](./terraform) directory you can run `terraform apply` to build the backend.
 
+The terraform infrastructure deployed through the CI/CD pipeline uses the `sso-requests-boundary` policy, which is scoped to its required resource types. If adding new resource types you will get a 403 forbidden. Expand the policy as needed.
+
 ## Tests
 
 This repository has frontend tests using jest and react testing library, and backend tests run with jest.

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -1,3 +1,9 @@
 provider "aws" {
   region = "ca-central-1"
+
+  default_tags {
+    tags = {
+      repository = "sso-requests"
+    }
+  }
 }

--- a/terraform/roles.tf
+++ b/terraform/roles.tf
@@ -1,3 +1,7 @@
+data "aws_iam_policy" "permissions_boundary_policy" {
+  name = "sso-requests-boundary"
+}
+
 # ECS task execution role data
 data "aws_iam_policy_document" "ecs_task_execution_role" {
   version = "2012-10-17"
@@ -20,9 +24,10 @@ data "aws_iam_policy" "grafana_read_secret" {
 
 # Grafana ECS task execution role
 resource "aws_iam_role" "grafana_task_execution_role" {
-  count              = var.install_grafana
-  name               = "GrafanaECSTaskExecutionRole"
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+  count                = var.install_grafana
+  name                 = "GrafanaECSTaskExecutionRole"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_task_execution_role.json
+  permissions_boundary = data.aws_iam_policy.permissions_boundary_policy.arn
 
   tags = var.grafana_tags
 }
@@ -64,8 +69,9 @@ EOF
 }
 
 resource "aws_iam_role" "grafana_container_role" {
-  count = var.install_grafana
-  name  = "grafana-container-role"
+  count                = var.install_grafana
+  name                 = "grafana-container-role"
+  permissions_boundary = data.aws_iam_policy.permissions_boundary_policy.arn
 
   assume_role_policy = <<EOF
 {
@@ -136,9 +142,10 @@ resource "aws_iam_role_policy" "grafana_container_efs_access" {
 
 # Redis ECS task execution role
 resource "aws_iam_role" "redis_task_execution_role" {
-  count              = var.install_redis
-  name               = "RedisECSTaskExecutionRole"
-  assume_role_policy = data.aws_iam_policy_document.ecs_task_execution_role.json
+  count                = var.install_redis
+  name                 = "RedisECSTaskExecutionRole"
+  assume_role_policy   = data.aws_iam_policy_document.ecs_task_execution_role.json
+  permissions_boundary = data.aws_iam_policy.permissions_boundary_policy.arn
 
   tags = var.grafana_tags
 }


### PR DESCRIPTION
scope down the terraform service account permission. Uses the same setup as sso-dashboard with a different boundary:

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "Allow",
            "Effect": "Allow",
            "Action": [
                "s3:*",
                "apigateway:*",
                "lambda:*",
                "ecs:*",
                "ec2:*",
                "elasticloadbalancing:*",
                "cloudwatch:*",
                "dynamodb:*",
                "rds:*",
                "acm:*",
                "events:*",
                "secretsmanager:GetSecretValue",
                "elasticfilesystem:*"
            ],
            "Resource": "*"
        }
    ]
}
```