### PR TITLE
fix: client name updates at bcsc disabled

### DIFF
--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -276,7 +276,7 @@ export const createBCSCIntegration = async (env: string, integration: Integratio
 
     //TODO: update client name after BCSC team provides a way to update client name
     //bcscClient.clientName = bcscClientName;
-    //bcscClient.save();
+    bcscClient.save();
     await updateBCSCClient(bcscClient, integration);
   }
   const requiredScopes = await getRequiredBCSCScopes(integration.bcscAttributes);

--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -274,8 +274,9 @@ export const createBCSCIntegration = async (env: string, integration: Integratio
       bcscClient.archived = false;
     }
 
-    bcscClient.clientName = bcscClientName;
-    bcscClient.save();
+    //TODO: update client name after BCSC team provides a way to update client name
+    //bcscClient.clientName = bcscClientName;
+    //bcscClient.save();
     await updateBCSCClient(bcscClient, integration);
   }
   const requiredScopes = await getRequiredBCSCScopes(integration.bcscAttributes);


### PR DESCRIPTION
Disabling client name updates until BCSC side could apply a patch to their DCR API to allow such updates.