### PR TITLE
feat: disable jwks_uri and update bcsc api conditionally

### DIFF
--- a/lambda/__tests__/20.bcsc.test.ts
+++ b/lambda/__tests__/20.bcsc.test.ts
@@ -57,6 +57,14 @@ jest.mock('@lambda-app/bcsc/client', () => {
   };
 });
 
+jest.mock('@lambda-app/queries/request', () => {
+  const original = jest.requireActual('@lambda-app/queries/request');
+  return {
+    ...original,
+    getIntegrationById: jest.fn(() => Promise.resolve({ lastChanges: [] })),
+  };
+});
+
 const OLD_ENV = process.env;
 beforeEach(() => {
   jest.resetModules();

--- a/lambda/app/src/bcsc/client.ts
+++ b/lambda/app/src/bcsc/client.ts
@@ -46,7 +46,7 @@ const getPrivacyZoneURI = async (env: string, privacyZoneDisplayName: string) =>
 export const createBCSCClient = async (data: BCSCClientParameters, integration: IntegrationData, userId: number) => {
   const contacts = await getBCSCContacts(integration);
   const { bcscBaseUrl, kcBaseUrl, accessToken } = getBCSCEnvVars(data.environment);
-  const jwksUri = `${kcBaseUrl}/auth/realms/standard/protocol/openid-connect/certs`;
+  //const jwksUri = `${kcBaseUrl}/auth/realms/standard/protocol/openid-connect/certs`;
   const requiredScopes = await getRequiredBCSCScopes(integration.bcscAttributes);
   let bcscPrivacyZoneURI = await getPrivacyZoneURI(data.environment, integration.bcscPrivacyZone);
 
@@ -64,7 +64,8 @@ export const createBCSCClient = async (data: BCSCClientParameters, integration: 
       // Sub must be requested. Otherwise id token will have a randomized identifier.
       claims: [...integration.bcscAttributes, 'sub'],
       privacy_zone_uri: bcscPrivacyZoneURI,
-      jwks_uri: jwksUri,
+      // TODO: Keep it commented until encryption is allowed
+      //jwks_uri: jwksUri,
     },
     {
       headers: {
@@ -79,7 +80,7 @@ export const createBCSCClient = async (data: BCSCClientParameters, integration: 
 export const updateBCSCClient = async (bcscClient: BCSCClientParameters, integration: IntegrationData) => {
   const { kcBaseUrl, bcscBaseUrl } = getBCSCEnvVars(bcscClient.environment);
   const contacts = await getBCSCContacts(integration);
-  const jwksUri = `${kcBaseUrl}/auth/realms/standard/protocol/openid-connect/certs`;
+  //const jwksUri = `${kcBaseUrl}/auth/realms/standard/protocol/openid-connect/certs`;
   const requiredScopes = await getRequiredBCSCScopes(integration.bcscAttributes);
 
   const result = await axios.put(
@@ -94,7 +95,8 @@ export const updateBCSCClient = async (bcscClient: BCSCClientParameters, integra
       id_token_signed_response_alg: 'RS256',
       userinfo_signed_response_alg: 'RS256',
       claims: [...integration.bcscAttributes, 'sub'],
-      jwks_uri: jwksUri,
+      // TODO: Keep it commented until encryption is allowed
+      //jwks_uri: jwksUri,
       client_id: bcscClient.clientId,
       registration_access_token: bcscClient.registrationAccessToken,
       privacy_zone_uri: await getPrivacyZoneURI(bcscClient.environment, integration.bcscPrivacyZone),

--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -278,7 +278,7 @@ export const createBCSCIntegration = async (env: string, integration: Integratio
     bcscClient.clientName = bcscClientName;
     bcscClient.save();
 
-    const integrationLastChanges = await getIntegrationById(integration.id).then((data) => data.lastChanges);
+    const integrationLastChanges = await getIntegrationById(integration.id).then((data) => data?.lastChanges);
 
     if (
       integrationLastChanges !== null &&

--- a/lambda/app/src/controllers/requests.ts
+++ b/lambda/app/src/controllers/requests.ts
@@ -31,6 +31,7 @@ import {
   getIntegrationsByUserTeam,
   getIntegrationByClientId,
   canUpdateRequestByUserId,
+  getIntegrationById,
 } from '@lambda-app/queries/request';
 import { fetchClient } from '@lambda-app/keycloak/client';
 import { getUserTeamRole } from '@lambda-app/queries/literals';
@@ -271,14 +272,29 @@ export const createBCSCIntegration = async (env: string, integration: Integratio
     bcscClientId = clientResponse.data.client_id;
   } else {
     if (bcscClient.archived) {
-      // TODO: currently need to have the BCSC team manually re-enable client when restoring (as of July 2024). Once api route for enabling is available should be added here.
       bcscClient.archived = false;
     }
 
-    //TODO: update client name after BCSC team provides a way to update client name
-    //bcscClient.clientName = bcscClientName;
+    bcscClient.clientName = bcscClientName;
     bcscClient.save();
-    await updateBCSCClient(bcscClient, integration);
+
+    const integrationLastChanges = await getIntegrationById(integration.id).then((data) => data.lastChanges);
+
+    if (
+      integrationLastChanges !== null &&
+      integrationLastChanges.find((change: any) =>
+        [
+          'projectName',
+          'bcscPrivacyZone',
+          'bcscAttributes',
+          'devHomePageUri',
+          'testHomePageUri',
+          'prodHomePageUri',
+        ].includes(change?.path[0]),
+      )
+    ) {
+      await updateBCSCClient(bcscClient, integration);
+    }
   }
   const requiredScopes = await getRequiredBCSCScopes(integration.bcscAttributes);
   const idpCreated = await getIdp(env, integration.clientId);
@@ -658,7 +674,7 @@ export const updateRequest = async (
     }
 
     const changes = getDifferences(finalData, originalData);
-    current.lastChanges = changes;
+    current.lastChanges = changes || null;
     let updated = await current.save();
 
     if (!updated) {

--- a/lambda/app/src/queries/request.ts
+++ b/lambda/app/src/queries/request.ts
@@ -168,12 +168,12 @@ export const getIntegrationsByUserTeam = async (
   });
 };
 
-export const getIntegrationById = (
+export const getIntegrationById = async (
   integrationId: number,
-  attributes: string[] = ['id', 'clientId', 'environments', 'teamId', 'devIdps'],
+  attributes: string[] = ['id', 'clientId', 'environments', 'teamId', 'devIdps', 'lastChanges'],
   options = { raw: true },
 ) => {
-  return models.request.findOne({
+  return await models.request.findOne({
     where: { id: integrationId, apiServiceAccount: false, archived: false },
     attributes,
     ...options,


### PR DESCRIPTION
1. The jwks_uri parameter is required only if encryption was enabled so removing it for now. 
2. The BCSC API is called only when creating a new or updating BCSC specific fields for existing one.