### PR TITLE
chore: version updates

### DIFF
--- a/.github/workflows/deploy-gh-pages-maintenance.yml
+++ b/.github/workflows/deploy-gh-pages-maintenance.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -75,7 +75,6 @@ jobs:
         run: |
           yarn
           yarn build
-          yarn export
           touch ./out/.nojekyll
         working-directory: ./app
 

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     strategy:
@@ -90,7 +90,6 @@ jobs:
         run: |
           yarn
           yarn build
-          yarn export
           touch ./out/.nojekyll
         working-directory: ./app
 

--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   k6-tests:
     name: K6 Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: hmarr/debug-action@v3
       - uses: actions/checkout@v4
@@ -30,6 +30,10 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-
 
+      - name: Install asdf requirements
+        run: |
+          sudo apt-get install -y libssl-dev libreadline-dev uuid-dev
+
       - name: Install asdf
         uses: asdf-vm/actions/setup@v3
       - name: Cache asdf tools
@@ -39,13 +43,8 @@ jobs:
             /home/runner/.asdf
           key: ${{ runner.os }}-${{ hashFiles('**/.tool-versions') }}
 
-      - name: Install required tools
-        run: |
-          sudo apt install uuid uuid-dev
-          cat .tool-versions | cut -f 1 -d ' ' | xargs -n 1 asdf plugin-add || true
-          asdf plugin-update --all
-          asdf install
-          asdf reshim
+      - name: Install asdf
+        uses: asdf-vm/actions/install@v3
 
       - name: Install dependencies for frontend
         run: make app_install

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -200,7 +200,6 @@ jobs:
 
           EOF
 
-      - uses: hmarr/debug-action@v3
       - uses: actions/checkout@v4
 
       - name: Get yarn cache directory path
@@ -248,6 +247,8 @@ jobs:
         run: |
           make build_all
         working-directory: ./lambda
+
+      - uses: hashicorp/setup-terraform@v3
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   terraform:
     permissions: write-all
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set env to development
         if: (github.ref == 'refs/heads/dev' && github.event_name == 'push') || (github.base_ref == 'dev' && github.event_name == 'pull_request')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,9 +4,8 @@ on: [push, pull_request]
 
 jobs:
   test_pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: hmarr/debug-action@v3
       - uses: actions/checkout@v4
 
       - name: Get yarn cache directory path
@@ -20,6 +19,10 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: ${{ runner.os }}-yarn-
 
+      - name: Install asdf requirements
+        run: |
+          sudo apt-get install -y libssl-dev libreadline-dev uuid-dev
+
       - name: Install asdf
         uses: asdf-vm/actions/setup@v3
       - name: Cache asdf tools
@@ -29,13 +32,8 @@ jobs:
             /home/runner/.asdf
           key: ${{ runner.os }}-${{ hashFiles('**/.tool-versions') }}
 
-      - name: Install required tools
-        run: |
-          sudo apt install uuid uuid-dev
-          cat .tool-versions | cut -f 1 -d ' ' | xargs -n 1 asdf plugin-add || true
-          asdf plugin-update --all
-          asdf install
-          asdf reshim
+      - name: Install asdf
+        uses: asdf-vm/actions/install@v3
 
       - name: Rerun Pre-Commit Hooks on CI
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
 nodejs 20.17.0
 yarn 1.22.4
-python 3.11.0
-postgres 11.4
+python 3.13.1
+postgres 13.15
 terraform 1.1.4
 terraform-docs 0.12.1
 tflint 0.41.0

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -2,6 +2,7 @@ const APP_URL = process.env.APP_URL || '';
 const BASE_PATH = process.env.APP_BASE_PATH || '';
 
 module.exports = {
+  output: 'export',
   reactStrictMode: true,
   serverRuntimeConfig: {},
   publicRuntimeConfig: {

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,7 @@
     "start": "next start",
     "lint": "next lint",
     "test": "jest",
-    "docker-build": "next build && next start",
+    "docker-build": "next build && npx --yes serve out",
     "jest-preview": "jest-preview"
   },
   "dependencies": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - 3000:3000
     environment:
       APP_ENV: develop
-      API_URL: /app
+      API_URL: http://localhost:8080/app
       SSO_URL: https://dev.loginproxy.gov.bc.ca/auth/realms/standard
       SSO_CLIENT_ID: css-app-in-gold-4128
       SSO_REDIRECT_URI: http://localhost:3000


### PR DESCRIPTION
- Update ubuntu runner to 24 in applicable github actions
- Update nextjs build syntax for the 14 migration, exporting for static builds has changed
- Match localdev postgres version to deployed version