### PR TITLE
chore: idp selection

### DIFF
--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -55,7 +55,7 @@ const HeaderContainer = styled.div`
   min-height: 150px;
 `;
 
-const filterIdps = (
+export const filterIdps = (
   currentIdps: string[] = [],
   updatedIdps: string[] = [],
   applied = true,

--- a/app/form-components/widgets/TooltipCheckboxesWidget.tsx
+++ b/app/form-components/widgets/TooltipCheckboxesWidget.tsx
@@ -4,6 +4,8 @@ import InfoOverlay from 'components/InfoOverlay';
 import styled from 'styled-components';
 import { SECONDARY_BLUE } from 'styles/theme';
 import { WidgetProps } from '@rjsf/utils/lib/types';
+import { filterIdps } from '../FormTemplate';
+import isEqual from 'lodash/isEqual';
 
 const AlphaTag = styled.span`
   background: ${SECONDARY_BLUE};
@@ -39,6 +41,7 @@ function TooltipCheckboxesWidget(props: WidgetProps) {
   const eOptions = Array.isArray(enumOptions) ? enumOptions : [];
   const eDisabled = Array.isArray(enumDisabled) ? enumDisabled : [];
   const eHidden = Array.isArray(enumHidden) ? enumHidden : [];
+  const formData = props.formContext.formData;
 
   return (
     <div className="checkboxes" id={id}>
@@ -58,9 +61,23 @@ function TooltipCheckboxesWidget(props: WidgetProps) {
               onChange={(event) => {
                 const all = eOptions.map(({ value }) => value);
                 if (event.target.checked) {
-                  onChange(selectValue(option.value, value, all));
+                  const newIdps = filterIdps(
+                    formData.devIdps,
+                    formData.devIdps.concat(option.value),
+                    formData.status === 'applied',
+                    formData.bceidApproved,
+                    formData.protocol,
+                  );
+                  if (!isEqual(formData.devIdps, newIdps)) onChange(selectValue(option.value, value, all));
                 } else {
-                  onChange(deselectValue(option.value, value));
+                  const newIdps = filterIdps(
+                    formData.devIdps,
+                    formData.devIdps.filter((idp: string) => idp !== option.value),
+                    formData.status === 'applied',
+                    formData.bceidApproved,
+                    formData.protocol,
+                  );
+                  if (!isEqual(formData.devIdps, newIdps)) onChange(deselectValue(option.value, value));
                 }
               }}
             />

--- a/app/form-components/widgets/TooltipIDPCheckboxesWidget.tsx
+++ b/app/form-components/widgets/TooltipIDPCheckboxesWidget.tsx
@@ -20,12 +20,9 @@ const WarningText = styled.p`
   margin-top: 0.2em;
 `;
 
-// https://github.com/rjsf-team/react-jsonschema-form/blob/master/packages/core/src/components/widgets/CheckboxesWidget.js
 function selectValue(value: string, selected: string[], all: string[]) {
   const at = all.indexOf(value);
   const updated = selected.slice(0, at).concat(value, selected.slice(at));
-  // As inserting values at predefined index positions doesn't work with empty
-  // arrays, we need to reorder the updated selection to match the initial order
   return updated.sort((a, b) => all.indexOf(a) - all.indexOf(b));
 }
 
@@ -33,7 +30,10 @@ function deselectValue(value: string, selected: string[]) {
   return selected.filter((v) => v !== value);
 }
 
-function TooltipCheckboxesWidget(props: WidgetProps) {
+/**
+ * Customized checkboxes widget for IDP selection. For a generic checkboxes example see https://github.com/rjsf-team/react-jsonschema-form/blob/main/packages/core/src/components/widgets/CheckboxesWidget.tsx
+ */
+function TooltipIDPCheckboxesWidget(props: WidgetProps) {
   const { id, disabled, options, value, autofocus = false, readonly, onChange, schema } = props;
   const { enumOptions, enumDisabled, enumHidden, inline = false } = options;
   const { tooltips, warningMessage } = schema as any & { tooltips: any[]; warningMessage: string };
@@ -114,4 +114,4 @@ function TooltipCheckboxesWidget(props: WidgetProps) {
   );
 }
 
-export default TooltipCheckboxesWidget;
+export default TooltipIDPCheckboxesWidget;

--- a/app/form-components/widgets/TooltipIDPCheckboxesWidget.tsx
+++ b/app/form-components/widgets/TooltipIDPCheckboxesWidget.tsx
@@ -3,7 +3,7 @@ import clsx from 'clsx';
 import InfoOverlay from 'components/InfoOverlay';
 import styled from 'styled-components';
 import { SECONDARY_BLUE } from 'styles/theme';
-import { WidgetProps } from '@rjsf/utils/lib/types';
+import { RJSFSchema, WidgetProps } from '@rjsf/utils/lib/types';
 import { filterIdps } from '../FormTemplate';
 import isEqual from 'lodash/isEqual';
 
@@ -36,7 +36,10 @@ function deselectValue(value: string, selected: string[]) {
 function TooltipIDPCheckboxesWidget(props: WidgetProps) {
   const { id, disabled, options, value, autofocus = false, readonly, onChange, schema } = props;
   const { enumOptions, enumDisabled, enumHidden, inline = false } = options;
-  const { tooltips, warningMessage } = schema as any & { tooltips: any[]; warningMessage: string };
+  const { tooltips, warningMessage } = schema as RJSFSchema & {
+    tooltips: { content: string; hide?: number; alpha?: boolean }[];
+    warningMessage: string;
+  };
 
   const eOptions = Array.isArray(enumOptions) ? enumOptions : [];
   const eDisabled = Array.isArray(enumDisabled) ? enumDisabled : [];
@@ -97,13 +100,13 @@ function TooltipIDPCheckboxesWidget(props: WidgetProps) {
 
         if (inline) {
           return (
-            <label key={index} className={classes}>
+            <label key={option.value} className={classes}>
               {checkbox}
             </label>
           );
         } else {
           return (
-            <div key={index} className={classes}>
+            <div key={option.value} className={classes}>
               <label>{checkbox}</label>
             </div>
           );

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -28,12 +28,4 @@ module.exports = {
   // basePath has to start with a /
   // basePath has to be either an empty string or a path prefix
   basePath: BASE_PATH,
-  async rewrites() {
-    return [
-      {
-        source: '/app/:path*',
-        destination: `http://${process.env.SSO_REQUESTS_BACKEND_HOSTNAME || 'localhost'}:8080/app/:path*`, // Proxy to Backend
-      },
-    ];
-  },
 };

--- a/app/schemas-ui/ui-gold.ts
+++ b/app/schemas-ui/ui-gold.ts
@@ -4,7 +4,7 @@ import FieldProjectTeam from '@app/form-components/FieldProjectTeam';
 import ClientTypeWidget from '@app/form-components/widgets/ClientTypeWidget';
 import ClientTokenWidget from '@app/form-components/widgets/ClientTokenWidget';
 import TooltipRadioWidget from '@app/form-components/widgets/TooltipRadioWidget';
-import TooltipCheckboxesWidget from '@app/form-components/widgets/TooltipCheckboxesWidget';
+import TooltipIDPCheckboxesWidget from '@app/form-components/widgets/TooltipIDPCheckboxesWidget';
 import FieldTermsAndConditions from '@app/form-components/FieldTermsAndConditions';
 import FieldRequesterInfo from '@app/form-components/FieldRequesterInfo';
 import FieldReviewAndSubmit from '@app/form-components/FieldReviewAndSubmit';
@@ -208,7 +208,7 @@ const getUISchema = ({ integration, formData, isAdmin, teams, schemas }: Props) 
       'ui:enumNames': ['Browser Login', 'Service Account', 'Browser Login and Service Account'],
     },
     devIdps: {
-      'ui:widget': TooltipCheckboxesWidget,
+      'ui:widget': TooltipIDPCheckboxesWidget,
       'ui:enumDisabled': idpDisabled,
       'ui:enumHidden': idpHidden,
       'ui:enumNames': schemas[1]?.properties?.devIdps?.items?.enum.map((idp: string) => idpMap[idp]) || [],


### PR DESCRIPTION
Fix bug with IDP selection to apply filtering again. With react 18 the child widget stopped re-rendering when the global handler applied idp filtering logic, so this moves it into the IDP selection widget.

Also removed rewrites from next config, this has been deprecated now and we set an env variable for the API base url so it is not needed