### PR TITLE
chore: signing alg

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -82,6 +82,8 @@ jobs:
           RDS_MIN_CAPACITY=0
           RDS_SCALE_DOWN_TIME=300
 
+          BCSC_SIGNING_ALGORITHM=PS256
+
           EOF
 
       - name: Set env to test
@@ -140,6 +142,8 @@ jobs:
           RDS_MIN_CAPACITY=0
           RDS_SCALE_DOWN_TIME=300
 
+          BCSC_SIGNING_ALGORITHM=RS256
+
           EOF
 
       - name: Set env to production
@@ -197,6 +201,8 @@ jobs:
           RDS_MAX_CAPACITY=2
           RDS_MIN_CAPACITY=0.5
           RDS_SCALE_DOWN_TIME=1800
+
+          BCSC_SIGNING_ALGORITHM=RS256
 
           EOF
 
@@ -344,6 +350,7 @@ jobs:
           rds_max_capacity="${{env.RDS_MAX_CAPACITY}}"
           rds_min_capacity="${{env.RDS_MIN_CAPACITY}}"
           rds_scale_down_time="${{env.RDS_SCALE_DOWN_TIME}}"
+          bcsc_signing_algorithm="${{env.BCSC_SIGNING_ALGORITHM}}"
           EOF
 
         working-directory: ./terraform

--- a/lambda/app/src/bcsc/client.ts
+++ b/lambda/app/src/bcsc/client.ts
@@ -59,8 +59,8 @@ export const createBCSCClient = async (data: BCSCClientParameters, integration: 
       scope: requiredScopes.join(' '),
       contacts: contacts,
       token_endpoint_auth_method: 'client_secret_post',
-      id_token_signed_response_alg: 'RS256',
-      userinfo_signed_response_alg: 'RS256',
+      id_token_signed_response_alg: process.env.BCSC_SIGNING_ALGORITHM || 'RS256',
+      userinfo_signed_response_alg: process.env.BCSC_SIGNING_ALGORITHM || 'RS256',
       // Sub must be requested. Otherwise id token will have a randomized identifier.
       claims: [...integration.bcscAttributes, 'sub'],
       privacy_zone_uri: bcscPrivacyZoneURI,
@@ -92,8 +92,8 @@ export const updateBCSCClient = async (bcscClient: BCSCClientParameters, integra
       scope: requiredScopes.join(' '),
       contacts,
       token_endpoint_auth_method: 'client_secret_post',
-      id_token_signed_response_alg: 'RS256',
-      userinfo_signed_response_alg: 'RS256',
+      id_token_signed_response_alg: process.env.BCSC_SIGNING_ALGORITHM || 'RS256',
+      userinfo_signed_response_alg: process.env.BCSC_SIGNING_ALGORITHM || 'RS256',
       claims: [...integration.bcscAttributes, 'sub'],
       // TODO: Keep it commented until encryption is allowed
       //jwks_uri: jwksUri,

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -247,3 +247,8 @@ variable "request_queue_rate" {
   # See https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule#argument-reference for formatting options.
   default = "rate(5 minutes)"
 }
+
+variable "bcsc_signing_algorithm" {
+  type    = string
+  default = "RS256"
+}


### PR DESCRIPTION
add env var for the bcsc signing algorithm. Setting to PS256 in sandbox only, and leaving the old RS256 in test/prod, since it is only avaiable in SIT right now