### PR TITLE
fix: integration fetch

### DIFF
--- a/lambda/__tests__/03.requests-by-users.test.ts
+++ b/lambda/__tests__/03.requests-by-users.test.ts
@@ -176,6 +176,18 @@ describe('create/manage integration by authenticated user', () => {
       expect(sendEmail).toHaveBeenCalled();
     });
 
+    it('should fetch an integration by userId when a draft team integration has not selected a team yet', async () => {
+      createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
+      let result = await createIntegration(getCreateIntegrationData({ projectName }));
+      result = await updateIntegration(
+        getUpdateIntegrationData({ integration: { ...result.body, usesTeam: true, teamId: null } }),
+      );
+
+      const retrieved = await getIntegrations();
+      const foundIntegration = retrieved.body.find((integration) => integration.id === result.body.id);
+      expect(foundIntegration).toBeTruthy();
+    });
+
     it('Should not allow public service accounts', async () => {
       createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
       const integrationClone = { ...integration };

--- a/lambda/__tests__/helpers/fixtures.ts
+++ b/lambda/__tests__/helpers/fixtures.ts
@@ -177,7 +177,7 @@ export const getUpdateIntegrationData = (args: {
     testIdps: envs.includes('test') ? identityProviders : [],
     prodIdps: envs.includes('prod') ? identityProviders : [],
     protocol,
-    teamId: args.integration.usesTeam ? args.integration.teamId.toString() : undefined,
+    teamId: args.integration.usesTeam ? args.integration.teamId?.toString() : undefined,
     authType,
     bceidApproved,
     githubApproved,

--- a/lambda/app/src/queries/request.ts
+++ b/lambda/app/src/queries/request.ts
@@ -31,6 +31,14 @@ export const getBaseWhereForMyOrTeamIntegrations = (userId: number, roles?: stri
       usesTeam: false,
       userId,
     },
+    // Cover case that users switched to team but have not selected one yet. This only applies in draft since
+    // request cannot be submitted until a team is selected.
+    {
+      usesTeam: true,
+      teamId: null,
+      status: 'draft',
+      userId,
+    },
   ];
 
   return where;


### PR DESCRIPTION
When an integration is in draft, users can toggle on "uses team" and leave before selecting a team from the dropdown. This is fine since they cannot submit for creation until choosing one, but had a bug where it would not show in the dashboard list anymore. This ticket updates the DB select to cover that case