### PR TITLE
chore: team selection in draft

### DIFF
--- a/app/cypress/fixtures/requests.json
+++ b/app/cypress/fixtures/requests.json
@@ -11,7 +11,7 @@
       "protocol": "oidc",
       "authtype": "browser-login",
       "publicaccess": true,
-      "identityprovider": ["GitHub BC Gov", "Basic or Business BCeID", "Digital Credential"],
+      "identityprovider": ["GitHub BC Gov", "Basic or Business BCeID", "Digital Credential", "Social"],
       "additionalroleattribute": "tbd",
       "environments": ["dev", "test", "prod"],
       "displayheader": false,
@@ -53,7 +53,8 @@
     },
     "approvals": {
       "bceid": true,
-      "github": true
+      "github": true,
+      "social": true
     },
     "devroles": {},
     "testroles": {},

--- a/app/cypress/fixtures/requests.json
+++ b/app/cypress/fixtures/requests.json
@@ -11,7 +11,7 @@
       "protocol": "oidc",
       "authtype": "browser-login",
       "publicaccess": true,
-      "identityprovider": ["GitHub BC Gov", "Basic or Business BCeID", "Digital Credential", "Social"],
+      "identityprovider": ["GitHub BC Gov", "Basic or Business BCeID", "Digital Credential"],
       "additionalroleattribute": "tbd",
       "environments": ["dev", "test", "prod"],
       "displayheader": false,
@@ -53,8 +53,7 @@
     },
     "approvals": {
       "bceid": true,
-      "github": true,
-      "social": true
+      "github": true
     },
     "devroles": {},
     "testroles": {},

--- a/app/cypress/pageObjects/requestPage.ts
+++ b/app/cypress/pageObjects/requestPage.ts
@@ -287,13 +287,9 @@ class RequestPage {
       }
     });
     // Agree to social when included
-    // cy.get('label')
-    //   .contains('Do you acknowledge and agree that by choosing social login')
-    //   .then(($label) => {
-    //     if ($label.length > 0) {
-    //       $label.click();
-    //     }
-    //   });
+    if (identityProviders.some((idp) => idp === 'Social')) {
+      cy.get('label').contains('Do you acknowledge and agree that by choosing social login').click();
+    }
   }
 
   setadditionalRoleAttribute(additionalRoleAttribute: string) {

--- a/app/cypress/pageObjects/requestPage.ts
+++ b/app/cypress/pageObjects/requestPage.ts
@@ -287,13 +287,13 @@ class RequestPage {
       }
     });
     // Agree to social when included
-    cy.get('label')
-      .contains('Do you acknowledge and agree that by choosing social login')
-      .then(($label) => {
-        if ($label.length > 0) {
-          $label.click();
-        }
-      });
+    // cy.get('label')
+    //   .contains('Do you acknowledge and agree that by choosing social login')
+    //   .then(($label) => {
+    //     if ($label.length > 0) {
+    //       $label.click();
+    //     }
+    //   });
   }
 
   setadditionalRoleAttribute(additionalRoleAttribute: string) {

--- a/app/jest/form.test.tsx
+++ b/app/jest/form.test.tsx
@@ -210,6 +210,27 @@ describe('Form Template Saving and Navigation', () => {
     fireEvent.click(adminReview);
     await waitFor(() => expect(within(termsAndConditionsBox).queryByTitle(STEPPER_ERROR)).toBeNull());
   });
+
+  it('Loads correct usesTeam state', async () => {
+    const withTeamComponent = await setUpRender({
+      id: 0,
+      status: 'draft',
+      usesTeam: true,
+      teamId: null,
+    });
+    let usesTeamCheckbox = withTeamComponent.getByLabelText('Project Team') as HTMLInputElement;
+    expect(usesTeamCheckbox.checked).toBe(true);
+    withTeamComponent.unmount();
+
+    const withoutTeamComponent = await setUpRender({
+      id: 0,
+      status: 'draft',
+      usesTeam: false,
+      teamId: null,
+    });
+    usesTeamCheckbox = withoutTeamComponent.getByLabelText('Project Team') as HTMLInputElement;
+    expect(usesTeamCheckbox.checked).toBe(false);
+  });
 });
 
 describe('Form Template Loading Data', () => {

--- a/app/utils/helpers.tsx
+++ b/app/utils/helpers.tsx
@@ -197,7 +197,7 @@ export const processRequest = (request: Integration): Integration => {
   }
 
   if (request.teamId) request.teamId = String(request.teamId);
-  else request.usesTeam = false;
+  else if (request.status !== 'draft') request.usesTeam = false;
 
   return changeNullToUndefined(request);
 };

--- a/lambda/shared/templates/helpers.ts
+++ b/lambda/shared/templates/helpers.ts
@@ -134,7 +134,7 @@ export const isNonProdDigitalCredentialRequest = (integration: IntegrationData) 
  * @param filename Name of the file
  */
 export const resolveAttachmentPath = (filename: string) => {
-  if (process.env.LOCAL_DEV) {
+  if (process.env.LOCAL_DEV === 'true') {
     return path.resolve(__dirname, 'attachments', filename);
   } else {
     return path.resolve(__dirname, filename);


### PR DESCRIPTION
- There was logic to set the usesTeam toggle false if there was no team id in the loaded data. In draft status, it is possible for users to have set this true and left before selecting a team, so updated to keep that data.
- Fix env variable check on attachments directory
- Fix social checkbox cypress check, contains was failing on non-social idps
