### PR TITLE
chore: delete enabling

### DIFF
--- a/app/components/ActionButtons.tsx
+++ b/app/components/ActionButtons.tsx
@@ -28,7 +28,7 @@ interface StyledActionButtonProps {
 }
 
 export const ActionButton = styled(({ disabled, activeColor, isUnread, ...props }) => (
-  <FontAwesomeIcon {...props} />
+  <FontAwesomeIcon {...props} aria-disabled={disabled} />
 ))<StyledActionButtonProps>`
   cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
   ${(props) =>

--- a/app/helpers/permissions.ts
+++ b/app/helpers/permissions.ts
@@ -1,6 +1,9 @@
 import { Integration } from '@app/interfaces/Request';
 import { Team } from '@app/interfaces/team';
 
+/**
+ * For an integration the user has access to, determine delete permissions.
+ */
 export const canDeleteIntegration = (integration: Integration) => {
   if (
     !integration ||
@@ -11,7 +14,7 @@ export const canDeleteIntegration = (integration: Integration) => {
     return false;
   }
 
-  if (integration.usesTeam) {
+  if (integration.usesTeam && integration.teamId) {
     if (integration.userTeamRole === 'admin') return true;
   } else return true;
 


### PR DESCRIPTION
allow draft deletion for partial team integrations (e.g. user switched to team but has not selected one yet)