### PR TITLE
chore: deleted user emails

### DIFF
--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -121,6 +121,7 @@ function MyApp({ Component, pageProps }: AppProps) {
         .init({
           redirectUri: sso_redirect_uri,
           onLoad: 'check-sso',
+          checkLoginIframe: false,
         })
         .then(() => {
           const processedSession = proccessSession(keycloak.idTokenParsed);
@@ -142,7 +143,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     if (session) getUser();
   }, [session]);
 
-  const handleLogin = async () => keycloak.login({ redirectUri: `${app_url}/my-dashboard` });
+  const handleLogin = async () => keycloak.login({ redirectUri: `${app_url}/my-dashboard`, idpHint: 'idir' });
   const handleLogout = async () => keycloak.logout({ redirectUri: app_url });
 
   const sessionContext = useMemo(() => ({ session, user, keycloak }), [session, user, keycloak]);

--- a/app/pages/_app.tsx
+++ b/app/pages/_app.tsx
@@ -121,7 +121,6 @@ function MyApp({ Component, pageProps }: AppProps) {
         .init({
           redirectUri: sso_redirect_uri,
           onLoad: 'check-sso',
-          checkLoginIframe: false,
         })
         .then(() => {
           const processedSession = proccessSession(keycloak.idTokenParsed);
@@ -143,7 +142,7 @@ function MyApp({ Component, pageProps }: AppProps) {
     if (session) getUser();
   }, [session]);
 
-  const handleLogin = async () => keycloak.login({ redirectUri: `${app_url}/my-dashboard`, idpHint: 'idir' });
+  const handleLogin = async () => keycloak.login({ redirectUri: `${app_url}/my-dashboard` });
   const handleLogout = async () => keycloak.logout({ redirectUri: app_url });
 
   const sessionContext = useMemo(() => ({ session, user, keycloak }), [session, user, keycloak]);

--- a/lambda/__tests__/11.remove-inactive-users.test.ts
+++ b/lambda/__tests__/11.remove-inactive-users.test.ts
@@ -3,9 +3,12 @@ import {
   SSO_TEAM_IDIR_EMAIL,
   SSO_TEAM_IDIR_USER,
   TEAM_ADMIN_IDIR_EMAIL_01,
+  TEAM_ADMIN_IDIR_EMAIL_02,
+  TEAM_ADMIN_IDIR_EMAIL_03,
   TEAM_ADMIN_IDIR_USERID_01,
   TEAM_ADMIN_IDIR_USERNAME_01,
   TEAM_MEMBER_IDIR_EMAIL_01,
+  TEAM_MEMBER_IDIR_USERID_01,
   postTeam,
   postTeamMembers,
 } from './helpers/fixtures';
@@ -15,9 +18,6 @@ import { Integration } from 'app/interfaces/Request';
 import { buildIntegration } from './helpers/modules/common';
 import { models } from '@lambda-shared/sequelize/models/models';
 import { EMAILS } from '@lambda-shared/enums';
-import { renderTemplate } from '@lambda-shared/templates';
-import { SSO_EMAIL_ADDRESS } from '@lambda-shared/local';
-import { deleteIntegration } from './helpers/modules/integrations';
 
 const testUser = {
   username: TEAM_ADMIN_IDIR_USERNAME_01,
@@ -29,6 +29,8 @@ const testUser = {
   clientData: {},
   env: 'prod',
 };
+
+const authenticateAsTestUser = () => createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
 
 jest.mock('../app/src/keycloak/integration', () => {
   const original = jest.requireActual('../app/src/keycloak/integration');
@@ -109,24 +111,20 @@ describe('users and teams', () => {
       emailList = createMockSendEmail();
       testUser.clientData = [{ client: teamIntegration.clientId, roles: ['test_role'] }];
       const deleteResponse = await deleteInactiveUsers(testUser);
-      const template = await renderTemplate(EMAILS.DELETE_INACTIVE_IDIR_USER, {
-        teamId: teamWithoutAdmins,
-        username: testUser.username,
-        clientId: testUser.clientData[0].client,
-        roles: testUser.clientData[0].roles[0],
-        teamAdmin: true,
-        env: 'prod',
-      });
       expect(deleteResponse.status).toEqual(200);
       const user = await models.user.findOne({ where: { idir_userid: TEAM_ADMIN_IDIR_USERID_01 }, raw: true });
       expect(user).toBeNull();
-      expect(emailList.length).toEqual(2);
-      expect(emailList[0].subject).toEqual(template.subject);
-      expect(emailList[0].body).toEqual(template.body);
-      expect(emailList[0].to.length).toEqual(1);
-      expect(emailList[0].to).toContain(TEAM_ADMIN_IDIR_EMAIL_01);
-      expect(emailList[0].cc.length).toEqual(1);
-      expect(emailList[0].cc[0]).toEqual(SSO_EMAIL_ADDRESS);
+
+      /* Expect 4 emails:
+        - User with roles deleted email
+        - Orphaned integration email for the directly owned request
+        - Orphaned integration email for the team request (since this was the only admin on it)
+        - Team update email
+      */
+      expect(emailList.length).toEqual(4);
+      expect(emailList.filter((email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER).length).toBe(1);
+      expect(emailList.filter((email) => email.code === EMAILS.ORPHAN_INTEGRATION).length).toBe(2);
+      expect(emailList.filter((email) => email.code === EMAILS.REMOVE_INACTIVE_IDIR_USER_FROM_TEAM).length).toBe(1);
     });
 
     it('should verify the admin status of sso team user in team with only admin', async () => {
@@ -170,131 +168,237 @@ describe('Deleted user emails', () => {
 
   beforeEach(async () => {
     await models.user.create({ idirUserid: SSO_TEAM_IDIR_USER, idirEmail: SSO_TEAM_IDIR_EMAIL });
-    createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
+    await models.user.create({ idirUserid: TEAM_ADMIN_IDIR_USERID_01, idirEmail: TEAM_ADMIN_IDIR_EMAIL_01 });
   });
 
-  it('Sends one email notification when a deleted user owns an integration directly', async () => {
-    const emailList = createMockSendEmail();
-    const request = await buildIntegration({
-      projectName: 'Delete Inactive Users',
-      bceid: false,
-      prodEnv: false,
-      submitted: true,
+  describe('Roles Emails', () => {
+    beforeEach(async () => {
+      authenticateAsTestUser();
     });
-    testUser.clientData = [{ client: request.body.clientId, roles: ['role1', 'role2'] }];
-    await deleteInactiveUsers(testUser);
-    const orphanedIntegrationEmails = emailList.filter((email) => email.code === EMAILS.ORPHAN_INTEGRATION);
-    const deleteInactiveIntegrationEmails = emailList.filter(
-      (email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER,
-    );
-    expect(orphanedIntegrationEmails.length).toBe(1);
-    expect(deleteInactiveIntegrationEmails.length).toBe(0);
+
+    it('Sends the roles email to a direct integration owner when a user with roles on the integration is deleted', async () => {
+      const emailList = createMockSendEmail();
+      const request = await buildIntegration({
+        projectName: 'Delete Inactive Users',
+        bceid: false,
+        prodEnv: false,
+        submitted: true,
+      });
+      testUser.clientData = [{ client: request.body.clientId, roles: ['role1', 'role2'] }];
+
+      await deleteInactiveUsers(testUser);
+      const deleteInactiveIntegrationEmails = emailList.filter(
+        (email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER,
+      );
+      expect(deleteInactiveIntegrationEmails.length).toBe(1);
+      expect(deleteInactiveIntegrationEmails[0].to.includes(TEAM_ADMIN_IDIR_EMAIL_01)).toBeTruthy();
+      expect(deleteInactiveIntegrationEmails[0].to.length).toBe(1);
+    });
+
+    it('Does not send the roles email if no client roles are provided', async () => {
+      const emailList = createMockSendEmail();
+      await buildIntegration({
+        projectName: 'Delete Inactive Users',
+        bceid: false,
+        prodEnv: false,
+        submitted: true,
+      });
+      testUser.clientData = [];
+
+      await deleteInactiveUsers(testUser);
+      const deleteInactiveIntegrationEmails = emailList.filter(
+        (email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER,
+      );
+      expect(deleteInactiveIntegrationEmails.length).toBe(0);
+    });
+
+    it('Sends the roles email to all team admins and members when a user with roles on the integration is deleted', async () => {
+      const emailList = createMockSendEmail();
+      const adminTeam = await createTeam({
+        name: 'test_team',
+        members: [
+          {
+            idirEmail: TEAM_MEMBER_IDIR_EMAIL_01,
+            role: 'member',
+          },
+          {
+            idirEmail: TEAM_ADMIN_IDIR_EMAIL_01,
+            role: 'admin',
+          },
+        ],
+      });
+      await updateTeamMembers(adminTeam.body.id);
+
+      const request = await buildIntegration({
+        projectName: 'Delete Inactive Users',
+        bceid: false,
+        prodEnv: false,
+        submitted: true,
+        teamId: adminTeam.body.id,
+      });
+
+      testUser.clientData = [{ client: request.body.clientId, roles: ['role1', 'role2'] }];
+      await deleteInactiveUsers(testUser);
+      const deleteInactiveIntegrationEmails = emailList.filter(
+        (email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER,
+      );
+      expect(deleteInactiveIntegrationEmails.length).toBe(1);
+      expect(deleteInactiveIntegrationEmails[0].to.includes(TEAM_MEMBER_IDIR_EMAIL_01)).toBeTruthy();
+      expect(deleteInactiveIntegrationEmails[0].to.includes(TEAM_ADMIN_IDIR_EMAIL_01)).toBeTruthy();
+    });
   });
 
-  it('Sends one email notification when a deleted user with no roles is the admin of the owning team', async () => {
-    const emailList = createMockSendEmail();
-    const adminTeam = await createTeam({
-      name: 'test_team',
-      members: [
-        {
-          idirEmail: TEAM_MEMBER_IDIR_EMAIL_01,
-          role: 'admin',
+  describe('Orphaned Emails', () => {
+    it('Sends the orphaned integration email to sso email address when the last team admin is deleted for each orphaned integration', async () => {
+      authenticateAsTestUser();
+      const emailList = createMockSendEmail();
+      // Authenticated user gets admin status on the created team.
+      const adminTeam = await createTeam({
+        name: 'test_team',
+        members: [
+          {
+            idirEmail: TEAM_MEMBER_IDIR_EMAIL_01,
+            role: 'member',
+          },
+        ],
+      });
+      await updateTeamMembers(adminTeam.body.id);
+      const firstProjectName = 'First Project';
+      const secondProjectName = 'Second Project';
+      await buildIntegration({
+        projectName: firstProjectName,
+        submitted: true,
+        teamId: adminTeam.body.id,
+      });
+      await buildIntegration({
+        projectName: secondProjectName,
+        submitted: true,
+        teamId: adminTeam.body.id,
+      });
+
+      await deleteInactiveUsers(testUser);
+      const deleteInactiveIntegrationEmails = emailList.filter((email) => email.code === EMAILS.ORPHAN_INTEGRATION);
+      expect(deleteInactiveIntegrationEmails.length).toBe(2);
+      expect(deleteInactiveIntegrationEmails[0].body.includes(firstProjectName)).toBeTruthy();
+      expect(deleteInactiveIntegrationEmails[1].body.includes(secondProjectName)).toBeTruthy();
+    });
+
+    it('Does not send the orphaned integration email when additional team admins exist', async () => {
+      authenticateAsTestUser();
+      const emailList = createMockSendEmail();
+      const adminTeam = await createTeam({
+        name: 'test_team',
+        members: [
+          {
+            idirEmail: TEAM_MEMBER_IDIR_EMAIL_01,
+            role: 'admin',
+          },
+        ],
+      });
+
+      await updateTeamMembers(adminTeam.body.id);
+      await buildIntegration({
+        projectName: 'project',
+        submitted: true,
+        teamId: adminTeam.body.id,
+      });
+
+      await deleteInactiveUsers(testUser);
+      const deleteInactiveIntegrationEmails = emailList.filter((email) => email.code === EMAILS.ORPHAN_INTEGRATION);
+      expect(deleteInactiveIntegrationEmails.length).toBe(0);
+    });
+
+    it('Sends the orphaned integration email to sso email address when a directly owned integration is deleted', async () => {
+      const emailList = createMockSendEmail();
+      authenticateAsTestUser();
+      await buildIntegration({
+        projectName: 'project',
+        submitted: true,
+      });
+      await deleteInactiveUsers(testUser);
+      const deleteInactiveIntegrationEmails = emailList.filter((email) => email.code === EMAILS.ORPHAN_INTEGRATION);
+      expect(deleteInactiveIntegrationEmails.length).toBe(1);
+    });
+  });
+
+  describe('Membership change', () => {
+    it('Sends the membership-change email to all other team admins, but not team members', async () => {
+      authenticateAsTestUser();
+      const emailList = createMockSendEmail();
+      const adminTeam = await createTeam({
+        name: 'test_team',
+        members: [
+          {
+            idirEmail: TEAM_ADMIN_IDIR_EMAIL_02,
+            role: 'admin',
+          },
+          {
+            idirEmail: TEAM_ADMIN_IDIR_EMAIL_03,
+            role: 'admin',
+          },
+          {
+            idirEmail: TEAM_MEMBER_IDIR_EMAIL_01,
+            role: 'member',
+          },
+        ],
+      });
+      await updateTeamMembers(adminTeam.body.id);
+      await buildIntegration({
+        projectName: 'project',
+        submitted: true,
+        teamId: adminTeam.body.id,
+      });
+
+      await deleteInactiveUsers(testUser);
+      const removeTeamMemberEmails = emailList.filter(
+        (email) => email.code === EMAILS.REMOVE_INACTIVE_IDIR_USER_FROM_TEAM,
+      );
+      expect(removeTeamMemberEmails.length).toBe(1);
+      expect(removeTeamMemberEmails[0].to.length).toBe(2);
+      expect(removeTeamMemberEmails[0].to.includes(TEAM_ADMIN_IDIR_EMAIL_02)).toBeTruthy();
+      expect(removeTeamMemberEmails[0].to.includes(TEAM_ADMIN_IDIR_EMAIL_03)).toBeTruthy();
+      expect(removeTeamMemberEmails[0].to.includes(TEAM_MEMBER_IDIR_EMAIL_01)).toBeFalsy();
+    });
+
+    it('Sends the membership-change email when non-admins leave', async () => {
+      // Create a member-user for the team
+      await models.user.create({ idirUserid: TEAM_MEMBER_IDIR_USERID_01, idirEmail: TEAM_MEMBER_IDIR_EMAIL_01 });
+      authenticateAsTestUser();
+      const emailList = createMockSendEmail();
+      const adminTeam = await createTeam({
+        name: 'test_team',
+        members: [
+          {
+            idirEmail: TEAM_MEMBER_IDIR_EMAIL_01,
+            role: 'member',
+          },
+        ],
+      });
+      await updateTeamMembers(adminTeam.body.id);
+      await buildIntegration({
+        projectName: 'project',
+        submitted: true,
+        teamId: adminTeam.body.id,
+      });
+
+      await deleteInactiveUsers({
+        username: TEAM_MEMBER_IDIR_USERID_01,
+        email: TEAM_MEMBER_IDIR_EMAIL_01,
+        attributes: {
+          idir_user_guid: TEAM_MEMBER_IDIR_USERID_01,
+          idir_username: TEAM_MEMBER_IDIR_USERID_01,
         },
-      ],
+        clientData: {},
+        env: 'prod',
+      });
+
+      const removeTeamMemberEmails = emailList.filter(
+        (email) => email.code === EMAILS.REMOVE_INACTIVE_IDIR_USER_FROM_TEAM,
+      );
+      expect(removeTeamMemberEmails.length).toBe(1);
+      expect(removeTeamMemberEmails[0].to.length).toBe(1);
+      expect(removeTeamMemberEmails[0].to.includes(TEAM_ADMIN_IDIR_EMAIL_01)).toBeTruthy();
     });
-
-    await buildIntegration({
-      projectName: 'Delete Inactive Users',
-      bceid: false,
-      prodEnv: false,
-      submitted: true,
-      teamId: adminTeam.body.id,
-    });
-    testUser.clientData = [];
-
-    await deleteInactiveUsers(testUser);
-    const orphanedIntegrationEmails = emailList.filter((email) => email.code === EMAILS.ORPHAN_INTEGRATION);
-    const deleteInactiveIntegrationEmails = emailList.filter(
-      (email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER,
-    );
-    expect(deleteInactiveIntegrationEmails.length).toBe(1);
-    expect(orphanedIntegrationEmails.length).toBe(0);
-  });
-
-  it('Sends one email notification when a deleted user with roles is the admin of the owning team', async () => {
-    const emailList = createMockSendEmail();
-    const adminTeam = await createTeam({
-      name: 'test_team',
-      members: [
-        {
-          idirEmail: TEAM_MEMBER_IDIR_EMAIL_01,
-          role: 'admin',
-        },
-      ],
-    });
-
-    const request = await buildIntegration({
-      projectName: 'Delete Inactive Users',
-      bceid: false,
-      prodEnv: false,
-      submitted: true,
-      teamId: adminTeam.body.id,
-    });
-    testUser.clientData = [{ client: request.body.clientId, roles: ['role1', 'role2'] }];
-
-    await deleteInactiveUsers(testUser);
-    const orphanedIntegrationEmails = emailList.filter((email) => email.code === EMAILS.ORPHAN_INTEGRATION);
-    const deleteInactiveIntegrationEmails = emailList.filter(
-      (email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER,
-    );
-    expect(deleteInactiveIntegrationEmails.length).toBe(1);
-    expect(deleteInactiveIntegrationEmails[0].body.includes('role1')).toBeTruthy();
-    expect(deleteInactiveIntegrationEmails[0].body.includes('role2')).toBeTruthy();
-    expect(orphanedIntegrationEmails.length).toBe(0);
-  });
-
-  it('Skips the notification if the integration has been archived', async () => {
-    const emailList = createMockSendEmail();
-
-    // Create a team and integration
-    const adminTeam = await createTeam({
-      name: 'test_team',
-      members: [
-        {
-          idirEmail: TEAM_MEMBER_IDIR_EMAIL_01,
-          role: 'admin',
-        },
-      ],
-    });
-    const request = await buildIntegration({
-      projectName: 'Delete Inactive Users',
-      bceid: false,
-      prodEnv: false,
-      submitted: true,
-      teamId: adminTeam.body.id,
-    });
-    // Archive the integration
-    await deleteIntegration(request.body.id);
-
-    // Call the endpoint with no roles, should be no email since deleted
-    await deleteInactiveUsers(testUser);
-    let deleteInactiveIntegrationEmails = emailList.filter((email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER);
-    let orphanedIntegrationEmails = emailList.filter((email) => email.code === EMAILS.ORPHAN_INTEGRATION);
-
-    expect(orphanedIntegrationEmails.length).toBe(0);
-    expect(deleteInactiveIntegrationEmails.length).toBe(0);
-
-    jest.clearAllMocks();
-
-    // Call the user deletion endpoint with client roles, expect no email since deleted
-    testUser.clientData = [{ client: request.body.clientId, roles: ['role1', 'role2'] }];
-    await deleteInactiveUsers(testUser);
-
-    deleteInactiveIntegrationEmails = emailList.filter((email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER);
-    orphanedIntegrationEmails = emailList.filter((email) => email.code === EMAILS.ORPHAN_INTEGRATION);
-
-    expect(orphanedIntegrationEmails.length).toBe(0);
-    expect(deleteInactiveIntegrationEmails.length).toBe(0);
   });
 });
 
@@ -340,8 +444,13 @@ describe('Environment Check', () => {
           idirEmail: TEAM_ADMIN_IDIR_EMAIL_01,
           role: 'admin',
         },
+        {
+          idirEmail: TEAM_ADMIN_IDIR_EMAIL_02,
+          role: 'admin',
+        },
       ],
     });
+    await updateTeamMembers(adminTeam.body.id);
     const request = await buildIntegration({
       projectName: 'Delete Inactive Users',
       bceid: false,
@@ -365,13 +474,16 @@ describe('Environment Check', () => {
       const deleteInactiveIntegrationEmails = emailList.filter(
         (email) => email.code === EMAILS.DELETE_INACTIVE_IDIR_USER,
       );
+      const deleteInactiteamMembershipChangeEmails = emailList.filter(
+        (email) => email.code === EMAILS.REMOVE_INACTIVE_IDIR_USER_FROM_TEAM,
+      );
       expect(deleteInactiveIntegrationEmails.length).toBe(1);
 
       // Only does team admin notification for prod users
       if (env === 'prod') {
-        expect(deleteInactiveIntegrationEmails[0].body.includes('Team Admin')).toBeTruthy();
+        expect(deleteInactiteamMembershipChangeEmails.length).toBe(1);
       } else {
-        expect(deleteInactiveIntegrationEmails[0].body.includes('Team Admin')).not.toBeTruthy();
+        expect(deleteInactiteamMembershipChangeEmails.length).toBe(0);
       }
 
       // Always sends role information

--- a/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
+++ b/lambda/__tests__/__snapshots__/06.email-templates.test.ts.snap
@@ -1143,16 +1143,9 @@ exports[`Email template snapshots Should return the expected email for DELETE_IN
 "<h3>Dear Pathfinder SSO friend,</h3>
 <p>
   The IDIR user with the idir username test-user has an inactive guid in our system. They have been removed from
-  client test-client in the dev environment and associated roles test-role
+  client test-client in the dev environment and associated roles test-role.
 </p>
 <p>
-  This user was also a Team Admin for your integration, to help ensure a transition to the appropriate admin, please
-  contact the Pathfinder SSO team,
-  <a href="mailto:bcgov.sso@gov.bc.ca" title="Pathfinder SSO" target="_blank" rel="noreferrer"> bcgov.sso@gov.bc.ca </a>
-  with the name of the new admin so we configure for you. Once the Admin is set up, you can remove the Pathfinder SSO
-  team as an admin.
-</p>
- <p>
   If you have any questions, please contact us by
   <a href="https://chat.developer.gov.bc.ca/channel/sso" target="_blank" title="Rocket Chat" rel="noreferrer">
     Rocket.Chat
@@ -1161,7 +1154,6 @@ exports[`Email template snapshots Should return the expected email for DELETE_IN
   <a href="mailto:bcgov.sso@gov.bc.ca" title="Pathfinder SSO" target="_blank" rel="noreferrer"> bcgov.sso@gov.bc.ca </a>
 </p>
 <p>Thank you.<br />Pathfinder SSO Team</p>
-
 "
 `;
 

--- a/lambda/app/src/controllers/user.ts
+++ b/lambda/app/src/controllers/user.ts
@@ -296,7 +296,7 @@ export const deleteStaleUsers = async (
           raw: true,
         });
         const otherAdminEmails = otherAdmins.reduce(
-          (acc, curr) => acc.concat(curr.idirEmail).concat(curr.additionalEmail || []),
+          (acc, curr) => acc.concat(curr.idirEmail).concat(curr.additionalEmail ?? []),
           [],
         );
         await sendTemplate(EMAILS.REMOVE_INACTIVE_IDIR_USER_FROM_TEAM, {

--- a/lambda/shared/enums.ts
+++ b/lambda/shared/enums.ts
@@ -38,6 +38,7 @@ export const EMAILS = {
   CREATE_TEAM_API_ACCOUNT_APPROVED: 'create-team-api-account-approved',
   DELETE_TEAM_API_ACCOUNT_SUBMITTED: 'delete-team-api-account-submitted',
   DELETE_INACTIVE_IDIR_USER: 'delete-inactive-idir-users',
+  REMOVE_INACTIVE_IDIR_USER_FROM_TEAM: 'remove-inactive-idir-user-from-team',
   SURVEY_COMPLETED: 'survey-completed-notification',
   RESTORE_INTEGRATION: 'restore-integration',
   RESTORE_TEAM_API_ACCOUNT: 'restore-team-api-account',

--- a/lambda/shared/sequelize/models/UserTeam.ts
+++ b/lambda/shared/sequelize/models/UserTeam.ts
@@ -1,5 +1,5 @@
 const init = (sequelize, DataTypes) => {
-  return sequelize.define(
+  const UsersTeam = sequelize.define(
     'usersTeam',
     {
       userId: {
@@ -23,8 +23,12 @@ const init = (sequelize, DataTypes) => {
     },
     {
       underscored: true,
+      associate: function (models) {
+        UsersTeam.belongsTo(models.team, { foreignKey: 'teamId', targetKey: 'id' });
+      },
     },
   );
+  return UsersTeam;
 };
 
 export default init;

--- a/lambda/shared/templates/delete-inactive-idir-users/delete-inactive-idir-users.html
+++ b/lambda/shared/templates/delete-inactive-idir-users/delete-inactive-idir-users.html
@@ -1,14 +1,6 @@
 <h3>Dear Pathfinder SSO friend,</h3>
 <p>
   The IDIR user with the idir username {{username}} has an inactive guid in our system. They have been removed from
-  client {{clientId}} in the {{env}} environment{{#if roles.length}} and associated roles {{roles}}{{/if}}
+  client {{clientId}} in the {{env}} environment and associated roles {{roles}}.
 </p>
-{{#if teamAdmin}}
-<p>
-  This user was also a Team Admin for your integration, to help ensure a transition to the appropriate admin, please
-  contact the Pathfinder SSO team,
-  <a href="mailto:bcgov.sso@gov.bc.ca" title="Pathfinder SSO" target="_blank" rel="noreferrer"> bcgov.sso@gov.bc.ca </a>
-  with the name of the new admin so we configure for you. Once the Admin is set up, you can remove the Pathfinder SSO
-  team as an admin.
-</p>
-{{/if}} {{> footer }}
+{{> footer }}

--- a/lambda/shared/templates/index.ts
+++ b/lambda/shared/templates/index.ts
@@ -18,6 +18,7 @@ import createTeamApiAccountSubmitted from './create-team-api-account-submitted';
 import createTeamApiAccountApproved from './create-team-api-account-approved';
 import deleteTeamApiAccountSubmitted from './delete-team-api-account-submitted';
 import deleteInactiveIdirUsers from './delete-inactive-idir-users';
+import removeInactiveIdirUserFromTeam from './remove-inactive-idir-user-from-team';
 import surveyCompleted from './survey-completed-notification';
 import restoreIntegration from './restore-integration';
 import restoreTeamApiAccount from './restore-team-api-account';
@@ -149,6 +150,9 @@ const getBuilder = (key: string) => {
       break;
     case EMAILS.DELETE_INACTIVE_IDIR_USER:
       builder = deleteInactiveIdirUsers;
+      break;
+    case EMAILS.REMOVE_INACTIVE_IDIR_USER_FROM_TEAM:
+      builder = removeInactiveIdirUserFromTeam;
       break;
     case EMAILS.SURVEY_COMPLETED:
       builder = surveyCompleted;

--- a/lambda/shared/templates/orphan-integration/orphan-integration.html
+++ b/lambda/shared/templates/orphan-integration/orphan-integration.html
@@ -1,7 +1,8 @@
 <h3>Hello Team,</h3>
 <p>
-  The requestor for the non-team integration with <strong>Request ID {{integration.id}}</strong> has been removed from
-  the system so it has been transitioned to
+  The {{#if integration.usesTeam}}last team admin for the integration{{else}}requestor for the non-team
+  integration{{/if}} with <strong>Request ID {{integration.id}}</strong> has been removed from the system so it has been
+  transitioned to
   <a href="mailto:bcgov.sso@gov.bc.ca" title="Pathfinder SSO" target="_blank" rel="noreferrer"> bcgov.sso@gov.bc.ca </a>
   team.
 </p>

--- a/lambda/shared/templates/remove-inactive-idir-user-from-team/index.ts
+++ b/lambda/shared/templates/remove-inactive-idir-user-from-team/index.ts
@@ -4,10 +4,9 @@ import { sendEmail } from '@lambda-shared/utils/ches';
 import { EMAILS } from '@lambda-shared/enums';
 import type { RenderResult } from '../index';
 import { SSO_EMAIL_ADDRESS } from '@lambda-shared/local';
-import { getIntegrationEmails } from '../helpers';
 
 const SUBJECT_TEMPLATE = `In-active IDIR User Removed`;
-const template = fs.readFileSync(__dirname + '/delete-inactive-idir-users.html', 'utf8');
+const template = fs.readFileSync(__dirname + '/remove-inactive-idir-user-from-team.html', 'utf8');
 
 const subjectHandler = Handlebars.compile(SUBJECT_TEMPLATE, { noEscape: true });
 const bodyHandler = Handlebars.compile(template, { noEscape: true });
@@ -20,8 +19,8 @@ export const render = async (originalData: any): Promise<RenderResult> => {
   };
 };
 
-export const send = async (data: any, rendered: RenderResult) => {
-  const emails = await getIntegrationEmails(data.integration);
+export const send = async (data: { emails: string[]; username: string; teamName: string }, rendered: RenderResult) => {
+  const { username, teamName, emails } = data;
   return sendEmail({
     code: EMAILS.DELETE_INACTIVE_IDIR_USER,
     to: emails,

--- a/lambda/shared/templates/remove-inactive-idir-user-from-team/index.ts
+++ b/lambda/shared/templates/remove-inactive-idir-user-from-team/index.ts
@@ -5,11 +5,11 @@ import { EMAILS } from '@lambda-shared/enums';
 import type { RenderResult } from '../index';
 import { SSO_EMAIL_ADDRESS } from '@lambda-shared/local';
 
-const SUBJECT_TEMPLATE = `In-active IDIR User Removed`;
+const SUBJECT_TEMPLATE = `In-active IDIR User Removed From Team`;
 const template = fs.readFileSync(__dirname + '/remove-inactive-idir-user-from-team.html', 'utf8');
 
-const subjectHandler = Handlebars.compile(SUBJECT_TEMPLATE, { noEscape: true });
 const bodyHandler = Handlebars.compile(template, { noEscape: true });
+const subjectHandler = Handlebars.compile(SUBJECT_TEMPLATE, { noEscape: true });
 
 export const render = async (originalData: any): Promise<RenderResult> => {
   const data = { ...originalData };
@@ -20,9 +20,9 @@ export const render = async (originalData: any): Promise<RenderResult> => {
 };
 
 export const send = async (data: { emails: string[]; username: string; teamName: string }, rendered: RenderResult) => {
-  const { username, teamName, emails } = data;
+  const { emails } = data;
   return sendEmail({
-    code: EMAILS.DELETE_INACTIVE_IDIR_USER,
+    code: EMAILS.REMOVE_INACTIVE_IDIR_USER_FROM_TEAM,
     to: emails,
     cc: [SSO_EMAIL_ADDRESS],
     ...rendered,

--- a/lambda/shared/templates/remove-inactive-idir-user-from-team/remove-inactive-idir-user-from-team.html
+++ b/lambda/shared/templates/remove-inactive-idir-user-from-team/remove-inactive-idir-user-from-team.html
@@ -1,0 +1,6 @@
+<h3>Dear Pathfinder SSO friend,</h3>
+<p>
+  The user {{username}} has an inactive guid in our system and has been automatically removed from your team
+  {{teamName}}.
+</p>
+{{> footer }}


### PR DESCRIPTION
Updated the user deletion emailing, separating out the messages:
- Sends the "user with role deleted" message separately from team memberships change
- Emails all integration owners when a user with client-roles on it is removed in any environment
- For users removed from production, moves any orphaned integrations to our team and notifies us
- Sends an email to all team-admins if any team member is deleted

I updated the unit tests checking for one email, since they are separated now. Added new tests for the different email cases