### PR TITLE
chore: update e2e tests

### DIFF
--- a/.github/workflows/e2e-keycloak.yaml
+++ b/.github/workflows/e2e-keycloak.yaml
@@ -48,12 +48,12 @@ jobs:
           path: app/cypress/screenshots/**/*
           if-no-files-found: ignore
 
-      # - uses: actions/upload-artifact@v4
-      #   if: failure()
-      #   with:
-      #     name: cypress-videos
-      #     path: app/cypress/videos/**/*
-      #     if-no-files-found: ignore
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-videos
+          path: app/cypress/videos/**/*
+          if-no-files-found: ignore
 
   idp-stopper:
     runs-on: ubuntu-latest
@@ -83,12 +83,12 @@ jobs:
           path: app/cypress/screenshots/**/*
           if-no-files-found: ignore
 
-      # - uses: actions/upload-artifact@v4
-      #   if: failure()
-      #   with:
-      #     name: cypress-videos
-      #     path: app/cypress/videos/**/*
-      #     if-no-files-found: ignore
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-videos
+          path: app/cypress/videos/**/*
+          if-no-files-found: ignore
 
   search-users:
     runs-on: ubuntu-latest
@@ -118,12 +118,12 @@ jobs:
           path: app/cypress/screenshots/**/*
           if-no-files-found: ignore
 
-      # - uses: actions/upload-artifact@v4
-      #   if: failure()
-      #   with:
-      #     name: cypress-videos
-      #     path: app/cypress/videos/**/*
-      #     if-no-files-found: ignore
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-videos
+          path: app/cypress/videos/**/*
+          if-no-files-found: ignore
 
   roles-tests:
     runs-on: ubuntu-latest
@@ -153,12 +153,12 @@ jobs:
           path: app/cypress/screenshots/**/*
           if-no-files-found: ignore
 
-      # - uses: actions/upload-artifact@v4
-      #   if: failure()
-      #   with:
-      #     name: cypress-videos
-      #     path: app/cypress/videos/**/*
-      #     if-no-files-found: ignore
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-videos
+          path: app/cypress/videos/**/*
+          if-no-files-found: ignore
 
   integration-tests:
     runs-on: ubuntu-latest
@@ -188,9 +188,9 @@ jobs:
           path: app/cypress/screenshots/**/*
           if-no-files-found: ignore
 
-      # - uses: actions/upload-artifact@v4
-      #   if: failure()
-      #   with:
-      #     name: cypress-videos
-      #     path: app/cypress/videos/**/*
-      #     if-no-files-found: ignore
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: cypress-videos
+          path: app/cypress/videos/**/*
+          if-no-files-found: ignore

--- a/.github/workflows/e2e-keycloak.yaml
+++ b/.github/workflows/e2e-keycloak.yaml
@@ -12,10 +12,10 @@ env:
   CYPRESS_siteminder: ${{ secrets.CYPRESS_SITEMINDER }}
   CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  CYPRESS_host: 'https://bcgov.github.io/sso-requests-sandbox/'
+  CYPRESS_host: 'https://sso-requests-sandbox.apps.gold.devops.gov.bc.ca/'
   CYPRESS_smoketest: false
   CYPRESS_localtest: false
-  CYPRESS_BASE_URL: 'https://bcgov.github.io/sso-requests-sandbox/'
+  CYPRESS_BASE_URL: 'https://sso-requests-sandbox.apps.gold.devops.gov.bc.ca/'
 
 jobs:
   pre-reqs:

--- a/.github/workflows/e2e-keycloak.yaml
+++ b/.github/workflows/e2e-keycloak.yaml
@@ -33,7 +33,7 @@ jobs:
         continue-on-error: false
         with:
           summary-title: 'Pre-reqs'
-          wait-on: https://bcgov.github.io/sso-requests-sandbox/
+          wait-on: https://sso-requests-sandbox.apps.gold.devops.gov.bc.ca/
           wait-on-timeout: 120
           install-command: yarn
           working-directory: app
@@ -68,7 +68,7 @@ jobs:
         continue-on-error: false
         with:
           summary-title: 'E2E tests'
-          wait-on: 'https://bcgov.github.io/sso-requests-sandbox/'
+          wait-on: 'https://sso-requests-sandbox.apps.gold.devops.gov.bc.ca/'
           wait-on-timeout: 360
           install-command: yarn
           working-directory: app
@@ -103,7 +103,7 @@ jobs:
         continue-on-error: false
         with:
           summary-title: 'E2E tests'
-          wait-on: 'https://bcgov.github.io/sso-requests-sandbox/'
+          wait-on: 'https://sso-requests-sandbox.apps.gold.devops.gov.bc.ca/'
           wait-on-timeout: 360
           install-command: yarn
           working-directory: app
@@ -138,7 +138,7 @@ jobs:
         continue-on-error: false
         with:
           summary-title: 'E2E tests'
-          wait-on: 'https://bcgov.github.io/sso-requests-sandbox/'
+          wait-on: 'https://sso-requests-sandbox.apps.gold.devops.gov.bc.ca/'
           wait-on-timeout: 360
           install-command: yarn
           working-directory: app
@@ -173,7 +173,7 @@ jobs:
         continue-on-error: false
         with:
           summary-title: 'E2E tests'
-          wait-on: 'https://bcgov.github.io/sso-requests-sandbox/'
+          wait-on: 'https://sso-requests-sandbox.apps.gold.devops.gov.bc.ca/'
           wait-on-timeout: 360
           install-command: yarn
           working-directory: app

--- a/app/cypress.config.ts
+++ b/app/cypress.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
     json: true,
   },
   e2e: {
-    baseUrl: 'https://bcgov.github.io/sso-requests-sandbox',
+    baseUrl: 'https://sso-requests-sandbox.apps.gold.devops.gov.bc.ca/',
     projectId: 'gctfmh',
     setupNodeEvents(on, config) {
       on('before:browser:launch', (browser, launchOptions) => {

--- a/app/cypress/appActions/Navigation.ts
+++ b/app/cypress/appActions/Navigation.ts
@@ -1,5 +1,4 @@
 class Navigation {
-  basePath: string = Cypress.env('localtest') ? '' : '/sso-requests-sandbox';
   waitForPageLoad() {
     // Wait for loader to appear and clear to ensure full page load
     cy.get('[data-testid="grid-loading"]').should('exist');
@@ -10,7 +9,7 @@ class Navigation {
     cy.url().then((url) => {
       cy.log(url);
       if (!url.includes('/my-dashboard') || url.includes('/teams')) {
-        cy.get(`header a[href="${this.basePath}/my-dashboard"]`).click();
+        cy.get(`header a[href="/my-dashboard"]`).click();
         this.waitForPageLoad();
       }
     });
@@ -23,7 +22,7 @@ class Navigation {
         cy.contains('My Teams').click();
         this.waitForPageLoad();
       } else {
-        cy.get(`header a[href="${this.basePath}/my-dashboard"]`).click();
+        cy.get(`header a[href="/my-dashboard"]`).click();
         cy.contains('My Teams').click();
         this.waitForPageLoad();
       }
@@ -32,7 +31,7 @@ class Navigation {
 
   goToAdminDashboard() {
     cy.url().then((url) => {
-      if (!url.endsWith('/admin-dashboard')) cy.get(`header a[href="${this.basePath}/admin-dashboard"]`).click();
+      if (!url.endsWith('/admin-dashboard')) cy.get(`header a[href="/admin-dashboard"]`).click();
     });
   }
 }

--- a/app/cypress/e2e/external/idpstopper-020-test11.cy.ts
+++ b/app/cypress/e2e/external/idpstopper-020-test11.cy.ts
@@ -25,59 +25,52 @@ describe('Run IDP Stopper Test', () => {
     // Only run the test if the smoketest flag is set and the test is a smoketest
     if (util.runOk(data)) {
       it(`Create ${data.create.projectname} (Test ID: ${data.create.test_id}) - ${data.create.description}`, () => {
+        let integration: Cypress.Chainable | undefined;
         cy.setid('admin').then(() => {
           cy.login();
         });
         req.showCreateContent(data);
         req.populateCreateContent(data);
-        req.createRequest();
+        integration = req.createRequest();
         cy.logout();
-      });
 
-      // Using the OIDC Playground to test the IDP Stopper
-      it('Go to Playground', () => {
-        Cypress.session.clearAllSavedSessions();
-        let playground = new Playground();
+        integration.then(() => {
+          let playground = new Playground();
 
-        cy.visit(playground.path);
+          cy.visit(playground.path);
 
-        playground.fillInPlayground(
-          null,
-          null,
-          kebabCase(data.create.projectname) + '-' + req.uid + '-' + Number(req.id),
-          null,
-        );
+          playground.fillInPlayground(
+            null,
+            null,
+            kebabCase(data.create.projectname) + '-' + req.uid + '-' + Number(req.id),
+            null,
+          );
 
-        playground.clickLogin();
+          playground.clickLogin();
 
-        cy.log(data.create.identityprovider[0]);
-        if (data.create.identityprovider[0] == 'Basic BCeID') {
-          cy.setid('bceidbasic').then(() => {
-            cy.log(Cypress.env('username'));
-            playground.loginBasicBCeID(Cypress.env('username'), Cypress.env('password'));
-          });
-        } else if (data.create.identityprovider[0] == 'Business BCeID') {
-          cy.setid('bceidbusiness').then(() => {
-            cy.log(Cypress.env('username'));
-            playground.loginBusinesBCeID(Cypress.env('username'), Cypress.env('password'));
-          });
-        } else if (data.create.identityprovider[0] == 'GitHub BC Gov') {
-          cy.setid('githubbcgov').then(() => {
-            cy.log(Cypress.env('username'));
-            const token = authenticator.generate(Cypress.env('otpsecret'));
-            playground.loginGithubbcGov(Cypress.env('username'), Cypress.env('password'), token);
-          });
-        } else if (data.create.identityprovider[0] == 'GitHub') {
-          cy.setid('githubpublic').then(() => {
-            cy.log(Cypress.env('username'));
-            const token = authenticator.generate(Cypress.env('otpsecret'));
-            playground.loginGithubbcGov(Cypress.env('username'), Cypress.env('password'), token);
-          });
-        }
-        cy.contains('a', 'Token Parsed', { timeout: 1000 }).click();
-        cy.contains('td', 'family_name').siblings().should('be.empty');
-        //contains('').should('be.visible');
-        playground.clickLogout();
+          if (data.create.identityprovider[0] == 'Basic BCeID') {
+            cy.setid('bceidbasic').then(() => {
+              playground.loginBasicBCeID(Cypress.env('username'), Cypress.env('password'));
+            });
+          } else if (data.create.identityprovider[0] == 'Business BCeID') {
+            cy.setid('bceidbusiness').then(() => {
+              playground.loginBusinesBCeID(Cypress.env('username'), Cypress.env('password'));
+            });
+          } else if (data.create.identityprovider[0] == 'GitHub BC Gov') {
+            cy.setid('githubbcgov').then(() => {
+              const token = authenticator.generate(Cypress.env('otpsecret'));
+              playground.loginGithubbcGov(Cypress.env('username'), Cypress.env('password'), token);
+            });
+          } else if (data.create.identityprovider[0] == 'GitHub') {
+            cy.setid('githubpublic').then(() => {
+              const token = authenticator.generate(Cypress.env('otpsecret'));
+              playground.loginGithubbcGov(Cypress.env('username'), Cypress.env('password'), token);
+            });
+          }
+          cy.contains('a', 'Token Parsed', { timeout: 1000 }).click();
+          cy.contains('td', 'family_name').siblings().should('be.empty');
+          playground.clickLogout();
+        });
       });
 
       it('Delete the request', () => {

--- a/app/cypress/e2e/external/idpstopper-050-login-page-name-capitalization.cy.ts
+++ b/app/cypress/e2e/external/idpstopper-050-login-page-name-capitalization.cy.ts
@@ -22,32 +22,31 @@ describe('Create Integration Requests For login page capitalization', () => {
   if (util.runOk(data[0])) {
     // Create an integration with 2 or more IDPs and an ssoheaderdev with capitalization
     it(`Create ${request.projectname} (Test ID: ${request.test_id}) - ${request.description}`, () => {
+      let integration: Cypress.Chainable | undefined;
+
       cy.setid(null).then(() => {
         cy.login();
       });
       req.showCreateContent(data[0]);
       req.populateCreateContent(data[0]);
-      req.createRequest();
+      integration = req.createRequest();
       cy.logout();
-    });
 
-    // Using the OIDC Playground to test the IDP Stopper
-    it('Go to Playground', () => {
-      console.log('Went to playground');
+      integration.then(() => {
+        cy.visit(playground.path);
+        cy.contains(playground.header);
 
-      cy.visit(playground.path);
-      cy.contains(playground.header);
+        playground.fillInPlayground(
+          null,
+          null,
+          kebabCase(request.projectname) + '-' + req.uid + '-' + Number(req.id),
+          null,
+        );
+        playground.clickLogin();
 
-      playground.fillInPlayground(
-        null,
-        null,
-        kebabCase(request.projectname) + '-' + req.uid + '-' + Number(req.id),
-        null,
-      );
-      playground.clickLogin();
-
-      // On the IDP Select Page, confirm the title is correctly capitalized.
-      cy.get('#kc-header-wrapper').contains(request.ssoheaderdev);
+        // On the IDP Select Page, confirm the title is correctly capitalized.
+        cy.get('#kc-header-wrapper').contains(request.ssoheaderdev);
+      });
     });
 
     it('Delete the request', () => {

--- a/app/cypress/e2e/external/sso-020-sessions.cy.ts
+++ b/app/cypress/e2e/external/sso-020-sessions.cy.ts
@@ -60,10 +60,8 @@ describe('SSO Tests', () => {
     it(`Test: "${data.id}": ${data.idp_hint_1}/ ${data.idp_hint_2}`, function () {
       //Isolate this session to be exclusively for the test otherwise context will be shared with other tests
       cy.session(data.id, () => {
-        cy.origin('https://dev.sandbox.loginproxy.gov.bc.ca', () => {
-          cy.on('uncaught:exception', (e) => {
-            return false;
-          });
+        cy.on('uncaught:exception', (e) => {
+          return false;
         });
 
         cy.visit(playground.path);

--- a/app/cypress/pageObjects/playgroundPage.ts
+++ b/app/cypress/pageObjects/playgroundPage.ts
@@ -65,6 +65,8 @@ class PlaygroundPage {
   }
 
   clickLogin() {
+    Cypress.session.clearAllSavedSessions();
+    cy.clearAllCookies();
     cy.contains(this.commonButton, 'Login', { timeout: 10000 }).click({ force: true });
   }
 

--- a/app/cypress/support/commands.ts
+++ b/app/cypress/support/commands.ts
@@ -14,18 +14,13 @@ Cypress.Commands.add('login', (username, password, host, siteminder) => {
   // Click the login button
   home.clickLoginButton();
 
-  cy.origin(Cypress.env('loginproxy'), () => {
-    cy.get('#kc-header-wrapper', { timeout: 10000 }).contains('COMMON HOSTED SINGLE SIGN-ON').should('be.visible');
-    cy.get('#social-idir', { timeout: 10000 }).click();
-  });
+  cy.get('#kc-header-wrapper', { timeout: 10000 }).contains('COMMON HOSTED SINGLE SIGN-ON').should('be.visible');
+  cy.get('#social-idir', { timeout: 10000 }).click();
 
-  // Validate siteminder and login
-  cy.origin(siteminder || Cypress.env('siteminder'), { args: sentArgs }, ({ user, pass }) => {
-    cy.get('#login-to', { timeout: 10000 }).contains('Log in to ').should('be.visible');
-    cy.get('#user', { timeout: 10000 }).type(user || Cypress.env('username'));
-    cy.get('#password', { timeout: 10000 }).type(pass || Cypress.env('password'), { log: false });
-    cy.get('input[name=btnSubmit]', { timeout: 10000 }).click();
-  });
+  cy.get('#login-to', { timeout: 10000 }).contains('Log in to ').should('be.visible');
+  cy.get('#user', { timeout: 10000 }).type(Cypress.env('username'));
+  cy.get('#password', { timeout: 10000 }).type(Cypress.env('password'), { log: false });
+  cy.get('input[name=btnSubmit]', { timeout: 10000 }).click();
 
   cy.contains('Common Hosted Single Sign-on (CSS)');
   cy.get('button', { timeout: 20000 }).contains('Log out').should('be.visible');

--- a/app/cypress/support/commands.ts
+++ b/app/cypress/support/commands.ts
@@ -8,8 +8,6 @@ Cypress.Commands.add('login', (username, password, host, siteminder) => {
   // Go to the host
   cy.visit(host || Cypress.env('host'));
 
-  const sentArgs = { user: username, pass: password };
-
   cy.contains('Common Hosted Single Sign-on (CSS)');
   // Click the login button
   home.clickLoginButton();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,7 +103,7 @@ services:
 
   dev-keycloak:
     container_name: dev-keycloak
-    image: ghcr.io/bcgov/sso:24.0.6-build.2
+    image: ghcr.io/bcgov/sso:26.0.7-build.1
 
     depends_on:
       - sso-db
@@ -140,7 +140,7 @@ services:
 
   test-keycloak:
     container_name: test-keycloak
-    image: ghcr.io/bcgov/sso:24.0.6-build.2
+    image: ghcr.io/bcgov/sso:26.0.7-build.1
 
     depends_on:
       - sso-db
@@ -177,7 +177,7 @@ services:
 
   prod-keycloak:
     container_name: prod-keycloak
-    image: ghcr.io/bcgov/sso:24.0.6-build.2
+    image: ghcr.io/bcgov/sso:26.0.7-build.1
 
     depends_on:
       - sso-db

--- a/local/terraform/main.tf
+++ b/local/terraform/main.tf
@@ -7,6 +7,7 @@ locals {
   bceidboth_realm_name                  = "bceidboth"
   github_realm_name                     = "github"
   digitalcredential_realm_name          = "digitalcredential"
+  otp_realm_name                        = "otp"
   sandbox_client_redirect_uri           = ""
   siteminder_single_sign_on_service_url = ""
 }
@@ -22,6 +23,7 @@ module "standard" {
   bceidbusiness_realm_name = local.bceidbusiness_realm_name
   bceidboth_realm_name     = local.bceidboth_realm_name
   github_realm_name        = local.github_realm_name
+  otp_realm_name           = local.otp_realm_name
 
   idir_client_id                      = ""
   idir_client_secret                  = ""
@@ -39,4 +41,7 @@ module "standard" {
   digitalcredential_client_secret     = ""
   digitalcredential_authorization_url = ""
   digitalcredential_token_url         = ""
+
+  otp_client_id     = ""
+  otp_client_secret = ""
 }


### PR DESCRIPTION
Update e2e tests to use new url:
- Un-comment videos in CI, they only upload on test failure and are almost always required for debugging
- Update URLs in CI
- Update tests hitting playground-app to keep integration details, switching to a different domain on github pages was losing the integration ID
- Remove cy.origin when going to loginproxy, since on the same domain now
- Update to recent keycloak image in CI test