### PR TITLE
chore: swagger url

### DIFF
--- a/.github/workflows/k6-tests.yml
+++ b/.github/workflows/k6-tests.yml
@@ -33,6 +33,7 @@ jobs:
 
       - name: Install asdf requirements
         run: |
+          sudo apt-get update
           sudo apt-get install -y libssl-dev libreadline-dev uuid-dev
 
       - name: Install asdf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
 
       - name: Install asdf requirements
         run: |
+          sudo apt-get update
           sudo apt-get install -y libssl-dev libreadline-dev uuid-dev
 
       - name: Install asdf

--- a/api/src/server.ts
+++ b/api/src/server.ts
@@ -33,7 +33,7 @@ app.use(
 
 const swaggerDocs = swaggerJsDoc(swaggerOptions);
 
-app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocs));
+app.use('/openapi/swagger', swaggerUi.serve, swaggerUi.setup(swaggerDocs));
 
 app.use(`/api/${process.env.API_VERSION}`, router);
 


### PR DESCRIPTION
- update swagger to the old location
- Update apt, was trying to find old mirrors that 404