### PR TITLE
chore: otp emails

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -77,7 +77,7 @@ jobs:
           BCSC_INITIAL_ACCESS_TOKEN_PROD=${{secrets.BCSC_INITIAL_ACCESS_TOKEN_TEST}}
           REDIS_HOST=${{secrets.TEST_REDIS_HOST}}
           GRAFANA_API_URL=https://sso-grafana-sandbox.apps.gold.devops.gov.bc.ca/api
-
+          EMAIL_ADDRESSES=${{secrets.DEV_EMAIL_ADDRESSES}}
 
           EOF
 
@@ -105,8 +105,7 @@ jobs:
           BCSC_INITIAL_ACCESS_TOKEN_PROD=${{secrets.BCSC_INITIAL_ACCESS_TOKEN_PROD}}
           REDIS_HOST=${{secrets.PROD_REDIS_HOST}}
           GRAFANA_API_URL=https://sso-grafana.apps.gold.devops.gov.bc.ca/api
-
-
+          EMAIL_ADDRESSES=${{secrets.PROD_EMAIL_ADDRESSES}}
           EOF
       - uses: actions/checkout@v4
       - name: Install CLI tools from OpenShift Mirror
@@ -213,6 +212,7 @@ jobs:
           --set envVars.bcscInitialAccessTokenDev="${{ env.BCSC_INITIAL_ACCESS_TOKEN_DEV }}" \
           --set envVars.bcscInitialAccessTokenProd="${{ env.BCSC_INITIAL_ACCESS_TOKEN_PROD }}" \
           --set envVars.bcscInitialAccessTokenTest="${{ env.BCSC_INITIAL_ACCESS_TOKEN_TEST }}" \
+          --set envVars.EMAIL_ADDRESSES="${{ env.EMAIL_ADDRESSES }}" \
           --set envVars.redisHost="${{ env.REDIS_HOST }}" \
           --set envVars.ghAccessToken="${{ secrets.GH_ACCESS_TOKEN }}" \
           --set envVars.verifyUserSecret="${{ env.VERIFY_USER_SECRET }}" \

--- a/app/.env.example
+++ b/app/.env.example
@@ -11,3 +11,13 @@ ENABLE_GOLD=true
 MAINTENANCE_MODE_ACTIVE=false
 APP_URL=http://localhost:3000
 INCLUDE_SOCIAL=true
+EMAIL_ADDRESSES={
+    "SSO_EMAIL_ADDRESS": "email@address.com",
+    "IDIM_EMAIL_ADDRESS": "email@address.com",
+    "OTP_EMAIL_ADDRESS_CC": ["email@address.com"],
+    "OTP_EMAIL_ADDRESS_BCC": ["email@address.com"],
+    "OCIO_EMAIL_ADDRESS": "email@address.com",
+    "DIT_EMAIL_ADDRESS":"email@address.com",
+    "DIT_ADDITIONAL_EMAIL_ADDRESS": "email@address.com",
+    "SOCIAL_APPROVAL_EMAIL_ADDRESS": "email@address.com"
+}

--- a/app/jest-api/07.emails-for-user-requests.test.ts
+++ b/app/jest-api/07.emails-for-user-requests.test.ts
@@ -528,7 +528,7 @@ describe('integration email updates for individual users', () => {
       expect(emailList[0].cc.length).toEqual(2);
       expect(emailList[0].cc.sort()).toEqual([SSO_EMAIL_ADDRESS, IDIM_EMAIL_ADDRESS].sort());
     });
-    it.only('should render the expected template after removing bc services card idp from prod integration', async () => {
+    it('should render the expected template after removing bc services card idp from prod integration', async () => {
       createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
       const projectName: string = 'Remove BCSC IDP Prod';
       let integrationRes = await buildIntegration({

--- a/app/jest-api/07.emails-for-user-requests.test.ts
+++ b/app/jest-api/07.emails-for-user-requests.test.ts
@@ -592,7 +592,7 @@ describe('integration email updates for individual users', () => {
       expect(emailList[1].cc.includes(SOCIAL_APPROVAL_EMAIL_ADDRESS)).toBeTruthy();
     });
 
-    it('should render the expected template after submission of a ont time passcode integration', async () => {
+    it('should render the expected template after submission of a one time passcode integration', async () => {
       process.env.INCLUDE_OTP = 'true';
       createMockAuth(TEAM_ADMIN_IDIR_USERID_01, TEAM_ADMIN_IDIR_EMAIL_01);
       emailList = createMockSendEmail();

--- a/app/jest-api/12.submit-survey.test.ts
+++ b/app/jest-api/12.submit-survey.test.ts
@@ -44,7 +44,7 @@ describe('Submit Survey', () => {
     expect(survey).not.toBeNull();
   });
 
-  it.only('sends an email to the user and CCs the SSO team when a survey is submitted', async () => {
+  it('sends an email to the user and CCs the SSO team when a survey is submitted', async () => {
     const userEmail = 'public.user@mail.com';
     createMockAuth(SSO_TEAM_IDIR_USER, userEmail);
     const emailList = createMockSendEmail();

--- a/app/jest-api/12.submit-survey.test.ts
+++ b/app/jest-api/12.submit-survey.test.ts
@@ -4,6 +4,7 @@ import { models } from '@app/shared/sequelize/models/models';
 import { createSurvey } from './helpers/modules/surveys';
 import { createMockAuth } from './mocks/authenticate';
 import { createMockSendEmail } from './mocks/mail';
+import { SSO_EMAIL_ADDRESS } from '@app/shared/local';
 
 const surveyData = {
   rating: 1,
@@ -43,13 +44,13 @@ describe('Submit Survey', () => {
     expect(survey).not.toBeNull();
   });
 
-  it('sends an email to the user and CCs the SSO team when a survey is submitted', async () => {
+  it.only('sends an email to the user and CCs the SSO team when a survey is submitted', async () => {
     const userEmail = 'public.user@mail.com';
     createMockAuth(SSO_TEAM_IDIR_USER, userEmail);
     const emailList = createMockSendEmail();
     await createSurvey(surveyData);
     expect(emailList.length).toBe(1);
     expect(emailList.find((email: any) => email.to.includes(userEmail))).toBeDefined();
-    expect(emailList.find((email: any) => email.cc.includes(SSO_TEAM_IDIR_EMAIL))).toBeDefined();
+    expect(emailList.find((email: any) => email.cc.includes(SSO_EMAIL_ADDRESS))).toBeDefined();
   });
 });

--- a/app/jest-api/jest.setup.js
+++ b/app/jest-api/jest.setup.js
@@ -10,6 +10,16 @@ process.env.INCLUDE_BC_SERVICES_CARD = true;
 process.env.ALLOW_BC_SERVICES_CARD_PROD = true;
 process.env.LOCAL_DEV = true;
 process.env.VERIFY_USER_SECRET = 'test';
+process.env.EMAIL_ADDRESSES = `{
+    "SSO_EMAIL_ADDRESS": "SSO_EMAIL_ADDRESS@address.com",
+    "IDIM_EMAIL_ADDRESS": "IDIM_EMAIL_ADDRESS@address.com",
+    "OTP_EMAIL_ADDRESS_CC": ["OTP_EMAIL_ADDRESS_CC@address.com"],
+    "OTP_EMAIL_ADDRESS_BCC": ["OTP_EMAIL_ADDRESS_BCC@address.com"],
+    "OCIO_EMAIL_ADDRESS": "OCIO_EMAIL_ADDRESS@address.com",
+    "DIT_EMAIL_ADDRESS":"DIT_EMAIL_ADDRESS@address.com",
+    "DIT_ADDITIONAL_EMAIL_ADDRESS": "DIT_ADDITIONAL_EMAIL_ADDRESS@address.com",
+    "SOCIAL_APPROVAL_EMAIL_ADDRESS": "SOCIAL_APPROVAL_EMAIL_ADDRESS@address.com"
+}`;
 
 beforeAll(async () => {
   await cleanUpDatabaseTables();

--- a/app/shared/local.ts
+++ b/app/shared/local.ts
@@ -3,18 +3,18 @@ const { EMAIL_ADDRESSES } = process.env;
 let parsedAddresses = {};
 
 try {
-    parsedAddresses = JSON.parse(EMAIL_ADDRESSES || '{}');
+  parsedAddresses = JSON.parse(EMAIL_ADDRESSES || '{}');
 } catch {
-    parsedAddresses = {}
+  parsedAddresses = {};
 }
 
 export const {
-    SSO_EMAIL_ADDRESS = "",
-    IDIM_EMAIL_ADDRESS = "",
-    OTP_EMAIL_ADDRESS_CC = "",
-    OTP_EMAIL_ADDRESS_BCC = "",
-    OCIO_EMAIL_ADDRESS = "",
-    SOCIAL_APPROVAL_EMAIL_ADDRESS = "",
-    DIT_EMAIL_ADDRESS = "",
-    DIT_ADDITIONAL_EMAIL_ADDRESS = "",
+  SSO_EMAIL_ADDRESS = '',
+  IDIM_EMAIL_ADDRESS = '',
+  OTP_EMAIL_ADDRESS_CC = '',
+  OTP_EMAIL_ADDRESS_BCC = '',
+  OCIO_EMAIL_ADDRESS = '',
+  SOCIAL_APPROVAL_EMAIL_ADDRESS = '',
+  DIT_EMAIL_ADDRESS = '',
+  DIT_ADDITIONAL_EMAIL_ADDRESS = '',
 } = parsedAddresses as any;

--- a/app/shared/local.ts
+++ b/app/shared/local.ts
@@ -18,20 +18,3 @@ export const {
     DIT_EMAIL_ADDRESS = "",
     DIT_ADDITIONAL_EMAIL_ADDRESS = "",
 } = parsedAddresses as any;
-
-// export const SSO_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
-
-// export const IDIM_EMAIL_ADDRESS = app_env === 'production' ? 'idim.consulting@gov.bc.ca' : 'bcgov.sso@gov.bc.ca';
-
-// export const OTP_EMAIL_ADDRESS_CC =
-//   app_env === 'production' ? ['dt.support@gov.bc.ca', 'ditrust@gov.bc.ca'] : ['bcgov.sso@gov.bc.ca'];
-// export const OTP_EMAIL_ADDRESS_BCC =
-//   app_env === 'production' ? ['jonathan-langlois@live.ca'] : ['jonathan-langlois@live.ca'];
-
-// export const OCIO_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
-
-// export const SOCIAL_APPROVAL_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
-
-// export const DIT_EMAIL_ADDRESS = 'ditrust@gov.bc.ca';
-
-// export const DIT_ADDITIONAL_EMAIL_ADDRESS = app_env === 'production' ? 'aaron.unger@gov.bc.ca' : 'bcgov.sso@gov.bc.ca';

--- a/app/shared/local.ts
+++ b/app/shared/local.ts
@@ -1,16 +1,37 @@
-import getConfig from 'next/config';
+const { EMAIL_ADDRESSES } = process.env;
 
-const { publicRuntimeConfig = {} } = getConfig() || {};
-const { app_env } = publicRuntimeConfig;
+let parsedAddresses = {};
 
-export const SSO_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
+try {
+    parsedAddresses = JSON.parse(EMAIL_ADDRESSES || '{}');
+} catch {
+    parsedAddresses = {}
+}
 
-export const IDIM_EMAIL_ADDRESS = app_env === 'production' ? 'idim.consulting@gov.bc.ca' : 'bcgov.sso@gov.bc.ca';
+export const {
+    SSO_EMAIL_ADDRESS = "",
+    IDIM_EMAIL_ADDRESS = "",
+    OTP_EMAIL_ADDRESS_CC = "",
+    OTP_EMAIL_ADDRESS_BCC = "",
+    OCIO_EMAIL_ADDRESS = "",
+    SOCIAL_APPROVAL_EMAIL_ADDRESS = "",
+    DIT_EMAIL_ADDRESS = "",
+    DIT_ADDITIONAL_EMAIL_ADDRESS = "",
+} = parsedAddresses as any;
 
-export const OCIO_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
+// export const SSO_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
 
-export const SOCIAL_APPROVAL_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
+// export const IDIM_EMAIL_ADDRESS = app_env === 'production' ? 'idim.consulting@gov.bc.ca' : 'bcgov.sso@gov.bc.ca';
 
-export const DIT_EMAIL_ADDRESS = 'ditrust@gov.bc.ca';
+// export const OTP_EMAIL_ADDRESS_CC =
+//   app_env === 'production' ? ['dt.support@gov.bc.ca', 'ditrust@gov.bc.ca'] : ['bcgov.sso@gov.bc.ca'];
+// export const OTP_EMAIL_ADDRESS_BCC =
+//   app_env === 'production' ? ['jonathan-langlois@live.ca'] : ['jonathan-langlois@live.ca'];
 
-export const DIT_ADDITIONAL_EMAIL_ADDRESS = app_env === 'production' ? 'aaron.unger@gov.bc.ca' : 'bcgov.sso@gov.bc.ca';
+// export const OCIO_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
+
+// export const SOCIAL_APPROVAL_EMAIL_ADDRESS = 'bcgov.sso@gov.bc.ca';
+
+// export const DIT_EMAIL_ADDRESS = 'ditrust@gov.bc.ca';
+
+// export const DIT_ADDITIONAL_EMAIL_ADDRESS = app_env === 'production' ? 'aaron.unger@gov.bc.ca' : 'bcgov.sso@gov.bc.ca';

--- a/app/shared/templates/create-integration-applied/index.ts
+++ b/app/shared/templates/create-integration-applied/index.ts
@@ -8,11 +8,13 @@ import {
   IDIM_EMAIL_ADDRESS,
   DIT_ADDITIONAL_EMAIL_ADDRESS,
   SOCIAL_APPROVAL_EMAIL_ADDRESS,
+  OTP_EMAIL_ADDRESS_CC,
+  OTP_EMAIL_ADDRESS_BCC,
 } from '@app/shared/local';
 import { getIntegrationEmails } from '../helpers';
 import { EMAILS } from '@app/shared/enums';
 import type { RenderResult } from '../index';
-import { usesBcServicesCardProd, usesBceidProd, usesDigitalCredentialProd, usesSocial } from '@app/helpers/integration';
+import { usesBcServicesCardProd, usesBceidProd, usesDigitalCredentialProd, usesOTPProd, usesSocial } from '@app/helpers/integration';
 
 const SUBJECT_TEMPLATE = `Pathfinder SSO request approved (email 2 of 2)`;
 const template = getEmailTemplate('create-integration-applied/create-integration-applied.html');
@@ -43,8 +45,13 @@ export const render = async (originalData: DataProps): Promise<RenderResult> => 
 export const send = async (data: DataProps, rendered: RenderResult) => {
   const { integration } = data;
   const emails = await getIntegrationEmails(integration);
-  const cc = [SSO_EMAIL_ADDRESS];
+  let cc = [SSO_EMAIL_ADDRESS];
+  let bcc: string[] = [];
   if (usesBceidProd(integration) || usesBcServicesCardProd(integration)) cc.push(IDIM_EMAIL_ADDRESS);
+  if (usesOTPProd(integration)) {
+    cc = cc.concat(OTP_EMAIL_ADDRESS_CC);
+    bcc = bcc.concat(OTP_EMAIL_ADDRESS_BCC);
+  }
   if (usesSocial(integration)) cc.push(SOCIAL_APPROVAL_EMAIL_ADDRESS);
   if (usesDigitalCredentialProd(integration)) {
     cc.push(DIT_EMAIL_ADDRESS, DIT_ADDITIONAL_EMAIL_ADDRESS);
@@ -54,6 +61,7 @@ export const send = async (data: DataProps, rendered: RenderResult) => {
     code: EMAILS.CREATE_INTEGRATION_APPLIED,
     to: emails,
     cc,
+    bcc,
     ...rendered,
   });
 };

--- a/app/shared/templates/create-integration-applied/index.ts
+++ b/app/shared/templates/create-integration-applied/index.ts
@@ -14,7 +14,13 @@ import {
 import { getIntegrationEmails } from '../helpers';
 import { EMAILS } from '@app/shared/enums';
 import type { RenderResult } from '../index';
-import { usesBcServicesCardProd, usesBceidProd, usesDigitalCredentialProd, usesOTPProd, usesSocial } from '@app/helpers/integration';
+import {
+  usesBcServicesCardProd,
+  usesBceidProd,
+  usesDigitalCredentialProd,
+  usesOTPProd,
+  usesSocial,
+} from '@app/helpers/integration';
 
 const SUBJECT_TEMPLATE = `Pathfinder SSO request approved (email 2 of 2)`;
 const template = getEmailTemplate('create-integration-applied/create-integration-applied.html');

--- a/app/shared/templates/create-integration-submitted/index.ts
+++ b/app/shared/templates/create-integration-submitted/index.ts
@@ -10,6 +10,8 @@ import {
   DIT_EMAIL_ADDRESS,
   DIT_ADDITIONAL_EMAIL_ADDRESS,
   SOCIAL_APPROVAL_EMAIL_ADDRESS,
+  OTP_EMAIL_ADDRESS_CC,
+  OTP_EMAIL_ADDRESS_BCC,
 } from '@app/shared/local';
 import { EMAILS } from '@app/shared/enums';
 import {
@@ -18,6 +20,7 @@ import {
   usesBcServicesCardProd,
   usesDigitalCredentialProd,
   usesSocial,
+  usesOTPProd,
 } from '@app/helpers/integration';
 import type { RenderResult } from '../index';
 
@@ -47,7 +50,8 @@ export const render = async (originalData: DataProps): Promise<RenderResult> => 
 export const send = async (data: DataProps, rendered: RenderResult) => {
   const { integration } = data;
   const emails = await getIntegrationEmails(integration);
-  const cc = [SSO_EMAIL_ADDRESS];
+  let cc = [SSO_EMAIL_ADDRESS];
+  let bcc: string[] = [];
   const attachments = [];
   if (usesBceidProd(integration) || usesBcServicesCardProd(integration)) cc.push(IDIM_EMAIL_ADDRESS);
   if (usesGithub(integration)) cc.push(OCIO_EMAIL_ADDRESS);
@@ -63,11 +67,16 @@ export const send = async (data: DataProps, rendered: RenderResult) => {
   if (usesDigitalCredentialProd(integration)) {
     cc.push(DIT_EMAIL_ADDRESS, DIT_ADDITIONAL_EMAIL_ADDRESS);
   }
+  if (usesOTPProd(integration)) {
+    cc = cc.concat(OTP_EMAIL_ADDRESS_CC);
+    bcc = bcc.concat(OTP_EMAIL_ADDRESS_BCC);
+  }
 
   return sendEmail({
     code: EMAILS.CREATE_INTEGRATION_SUBMITTED,
     to: emails,
     cc,
+    bcc,
     attachments,
     ...rendered,
   });

--- a/app/shared/templates/create-otp-bottom.html
+++ b/app/shared/templates/create-otp-bottom.html
@@ -1,7 +1,6 @@
 <strong>Next Steps for your integration with One Time Passcode (OTP):</strong>
 <p>
-  As you've requested an integration with OTP, any production integration request requires you to work with the Digital
-  Identity and Trust (DIT) team.
+  As you've requested an integration with OTP, any production integration request requires you to work with the Cybersecurity and Digital Trust (CDT) team.
 </p>
 <ol>
   <li>

--- a/app/shared/templates/create-otp-bottom.html
+++ b/app/shared/templates/create-otp-bottom.html
@@ -1,6 +1,7 @@
 <strong>Next Steps for your integration with One Time Passcode (OTP):</strong>
 <p>
-  As you've requested an integration with OTP, any production integration request requires you to work with the Cybersecurity and Digital Trust (CDT) team.
+  As you've requested an integration with OTP, any production integration request requires you to work with the
+  Cybersecurity and Digital Trust (CDT) team.
 </p>
 <ol>
   <li>

--- a/app/shared/templates/delete-integration-submitted/index.ts
+++ b/app/shared/templates/delete-integration-submitted/index.ts
@@ -9,6 +9,8 @@ import {
   OCIO_EMAIL_ADDRESS,
   DIT_ADDITIONAL_EMAIL_ADDRESS,
   DIT_EMAIL_ADDRESS,
+  OTP_EMAIL_ADDRESS_BCC,
+  OTP_EMAIL_ADDRESS_CC,
 } from '@app/shared/local';
 import { getIntegrationEmails } from '../helpers';
 import { EMAILS } from '@app/shared/enums';
@@ -18,6 +20,7 @@ import {
   usesBcServicesCardProd,
   usesDigitalCredentialProd,
   usesDigitalCredential,
+  usesOTPProd,
 } from '@app/helpers/integration';
 import type { RenderResult } from '../index';
 
@@ -45,16 +48,21 @@ export const render = async (originalData: DataProps): Promise<RenderResult> => 
 export const send = async (data: DataProps, rendered: RenderResult) => {
   const { integration } = data;
   const emails = await getIntegrationEmails(integration);
-  const cc = [SSO_EMAIL_ADDRESS];
+  let cc = [SSO_EMAIL_ADDRESS];
+  let bcc: string[] = [];
   if (usesBceidProd(integration) || usesBcServicesCardProd(integration)) cc.push(IDIM_EMAIL_ADDRESS);
   if (usesGithub(integration)) cc.push(OCIO_EMAIL_ADDRESS);
   if (usesDigitalCredential(integration)) cc.push(DIT_EMAIL_ADDRESS);
   if (usesDigitalCredentialProd(integration)) cc.push(DIT_ADDITIONAL_EMAIL_ADDRESS);
-
+  if (usesOTPProd(integration)) {
+    cc = cc.concat(OTP_EMAIL_ADDRESS_CC);
+    bcc = bcc.concat(OTP_EMAIL_ADDRESS_BCC);
+  }
   return sendEmail({
     code: EMAILS.DELETE_INTEGRATION_SUBMITTED,
     to: emails,
     cc,
+    bcc,
     ...rendered,
   });
 };

--- a/app/shared/templates/update-integration-submitted/index.ts
+++ b/app/shared/templates/update-integration-submitted/index.ts
@@ -10,6 +10,8 @@ import {
   DIT_EMAIL_ADDRESS,
   DIT_ADDITIONAL_EMAIL_ADDRESS,
   SOCIAL_APPROVAL_EMAIL_ADDRESS,
+  OTP_EMAIL_ADDRESS_CC,
+  OTP_EMAIL_ADDRESS_BCC,
 } from '@app/shared/local';
 import { getIntegrationEmails } from '../helpers';
 import { EMAILS } from '@app/shared/enums';
@@ -20,6 +22,7 @@ import {
   usesDigitalCredentialProd,
   usesDigitalCredential,
   usesSocial,
+  usesOTPProd,
 } from '@app/helpers/integration';
 import type { RenderResult } from '../index';
 
@@ -53,7 +56,8 @@ export const send = async (data: DataProps, rendered: RenderResult) => {
   const resettingBceidApproval = data.changes?.some(
     (change: any) => change.path[0] === 'bceidApproved' && change.lhs === true && change.rhs === false,
   );
-  const cc = [SSO_EMAIL_ADDRESS];
+  let cc = [SSO_EMAIL_ADDRESS];
+  let bcc: string[] = [];
   if (usesBceidProd(integration) || usesBcServicesCardProd(integration) || resettingBceidApproval)
     cc.push(IDIM_EMAIL_ADDRESS);
   if (usesGithub(integration)) cc.push(OCIO_EMAIL_ADDRESS);
@@ -70,11 +74,16 @@ export const send = async (data: DataProps, rendered: RenderResult) => {
       encoding: 'base64',
     });
   }
+  if (usesOTPProd(integration)) {
+    cc = cc.concat(OTP_EMAIL_ADDRESS_CC);
+    bcc = bcc.concat(OTP_EMAIL_ADDRESS_BCC);
+  }
 
   return sendEmail({
     code: EMAILS.UPDATE_INTEGRATION_SUBMITTED,
     to: emails,
     cc,
+    bcc,
     attachments,
     ...rendered,
   });

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -70,7 +70,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ include "..fullname" . }}
-                  key: email_addresses
+                  key: email-addresses
             - name: KEYCLOAK_V2_DEV_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -66,6 +66,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "..fullname" . }}
                   key: keycloak-v2-dev-username
+            - name: EMAIL_ADDRESSES
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "..fullname" . }}
+                  key: email_addresses
             - name: KEYCLOAK_V2_DEV_PASSWORD
               valueFrom:
                 secretKeyRef:

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -38,6 +38,7 @@ data:
   gh-access-token: {{  index $secret.data "gh-access-token" }}
   verify-user-secret: {{  index $secret.data "verify-user-secret" }}
   rc_webhook_url: {{  index $secret.data "rc_webhook_url" }}
+  email_addresses: {{  index $secret.data "email_addresses" }}
   {{- else }}
   app-url: {{ .Values.envVars.appUrl | b64enc }}
   api-auth-secret: {{ .Values.envVars.apiAuthSecret | b64enc }}
@@ -64,5 +65,6 @@ data:
   gh-access-token: {{ .Values.envVars.ghAccessToken | b64enc }}
   verify-user-secret: {{ .Values.envVars.verifyUserSecret | b64enc }}
   rc_webhook_url: {{ .Values.envVars.rc_webhook_url | b64enc }}
+  email_addresses: {{ .Values.envVars.email_addresses | b64enc }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Update email CC and BCC list for OTP integrations (create,delete,update). Adding olenas direct email to BCC was a requirement. I didn't want to commit that in code, so changed the email addresses to an env var. Instead of making 8 vars for each env I set it as the JSON structure that is in the .env.example