### PR TITLE
chore: helm condition

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -119,6 +119,7 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04
     needs: build-and-push-images
+    if: ${{ needs.build-and-push-images.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:


### PR DESCRIPTION
allow helm to run if images build passes