### PR TITLE
fix: token refresh

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -119,7 +119,7 @@ jobs:
       contents: read
     runs-on: ubuntu-24.04
     needs: build-and-push-images
-    if: ${{ needs.build-and-push-images.result == 'success' }}
+    if: ${{ always() && needs.build-and-push-images.result == 'success' }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/api/src/services/keycloak-service.ts
+++ b/api/src/services/keycloak-service.ts
@@ -45,7 +45,7 @@ export class KeycloakService {
         return response;
       },
       (error: AxiosError) => {
-        logger.error(error);
+        logger.error('Uncaught error in axios interceptor: ', error);
         throw error;
       },
     );

--- a/api/src/services/keycloak-service.ts
+++ b/api/src/services/keycloak-service.ts
@@ -90,11 +90,12 @@ export class KeycloakService {
         );
         this.accessToken = response.data.access_token;
         this.refreshToken = response.data.refresh_token;
+        return this.accessToken;
       } catch (e) {
         logger.error(`Error in token refresh: `, e);
+        return this.accessToken;
       } finally {
         this.refreshing = false;
-        return this.accessToken;
       }
     } else {
       try {
@@ -115,9 +116,9 @@ export class KeycloakService {
         );
         this.accessToken = response.data.access_token;
         this.refreshToken = response.data.refresh_token;
+        return this.accessToken;
       } catch (e) {
         logger.error('Error in access token request: ', e);
-      } finally {
         return this.accessToken;
       }
     }

--- a/api/src/services/keycloak-service.ts
+++ b/api/src/services/keycloak-service.ts
@@ -45,11 +45,7 @@ export class KeycloakService {
         return response;
       },
       (error: AxiosError) => {
-        logger.error('keycloak request path: ', error?.request?.path);
-        logger.error('keycloak request headers: ', error?.request?.headers);
-        logger.error('keycloak response status: ', error?.response?.status);
-        logger.error('keycloak response data: ', error?.response?.data);
-        logger.error('keycloak response status message: ', error?.response?.statusText);
+        logger.error(error);
         throw error;
       },
     );
@@ -78,42 +74,52 @@ export class KeycloakService {
         return this.accessToken;
       }
       this.refreshing = true;
-      const response = await this.httpClient.post<KeycloakTokenResponse>(
-        '/auth/realms/master/protocol/openid-connect/token',
-        new URLSearchParams({
-          grant_type: 'refresh_token',
-          refresh_token: this.refreshToken,
-          client_id: 'admin-cli',
-        }),
-        {
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
+      try {
+        const response = await this.httpClient.post<KeycloakTokenResponse>(
+          '/auth/realms/master/protocol/openid-connect/token',
+          new URLSearchParams({
+            grant_type: 'refresh_token',
+            refresh_token: this.refreshToken,
+            client_id: 'admin-cli',
+          }),
+          {
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
           },
-        },
-      );
-      this.accessToken = response.data.access_token;
-      this.refreshToken = response.data.refresh_token;
-      this.refreshing = false;
-      return this.accessToken;
+        );
+        this.accessToken = response.data.access_token;
+        this.refreshToken = response.data.refresh_token;
+      } catch (e) {
+        logger.error(`Error in token refresh: `, e);
+      } finally {
+        this.refreshing = false;
+        return this.accessToken;
+      }
     } else {
-      const { keycloakUsername, keycloakPassword } = getKeycloakCredentials(this.environment);
-      const response = await this.httpClient.post<KeycloakTokenResponse>(
-        '/auth/realms/master/protocol/openid-connect/token',
-        new URLSearchParams({
-          grant_type: 'password',
-          username: keycloakUsername,
-          password: keycloakPassword,
-          client_id: 'admin-cli',
-        }),
-        {
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
+      try {
+        const { keycloakUsername, keycloakPassword } = getKeycloakCredentials(this.environment);
+        const response = await this.httpClient.post<KeycloakTokenResponse>(
+          '/auth/realms/master/protocol/openid-connect/token',
+          new URLSearchParams({
+            grant_type: 'password',
+            username: keycloakUsername,
+            password: keycloakPassword,
+            client_id: 'admin-cli',
+          }),
+          {
+            headers: {
+              'Content-Type': 'application/x-www-form-urlencoded',
+            },
           },
-        },
-      );
-      this.accessToken = response.data.access_token;
-      this.refreshToken = response.data.refresh_token;
-      return this.accessToken;
+        );
+        this.accessToken = response.data.access_token;
+        this.refreshToken = response.data.refresh_token;
+      } catch (e) {
+        logger.error('Error in access token request: ', e);
+      } finally {
+        return this.accessToken;
+      }
     }
   }
 

--- a/api/src/tests/keycloak-service.test.ts
+++ b/api/src/tests/keycloak-service.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 // Ignoring ts since test needs to frequently setup private class variables
-import axios, { AxiosError, AxiosInstance } from 'axios';
+import axios, { AxiosInstance } from 'axios';
 import 'reflect-metadata';
 import { KeycloakService } from '@/services/keycloak-service';
 

--- a/api/src/tests/keycloak-service.test.ts
+++ b/api/src/tests/keycloak-service.test.ts
@@ -1,0 +1,147 @@
+// @ts-nocheck
+// Ignoring ts since test needs to frequently setup private class variables
+import axios, { AxiosError, AxiosInstance } from 'axios';
+import 'reflect-metadata';
+import { KeycloakService } from '@/services/keycloak-service';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+const mockAxiosInstance = {
+  get: jest.fn(),
+  post: jest.fn(),
+  put: jest.fn(),
+  delete: jest.fn(),
+  interceptors: {
+    response: {
+      use: jest.fn(),
+    },
+  },
+} as unknown as AxiosInstance;
+mockedAxios.create.mockReturnValue(mockAxiosInstance);
+
+function generateFakeJWT(payload: Record<string, any>): string {
+  const header = {
+    alg: 'RS256',
+    typ: 'JWT',
+  };
+  const base64Encode = (obj: object) => Buffer.from(JSON.stringify(obj)).toString('base64url');
+  const encodedHeader = base64Encode(header);
+  const encodedPayload = base64Encode(payload);
+  return `${encodedHeader}.${encodedPayload}.signature`;
+}
+
+describe('Keycloak Token Requests', () => {
+  let originalAccessToken: string;
+  let originalRefreshToken: string;
+  const KeycloakClient = new KeycloakService();
+  KeycloakClient.setEnvironment('dev');
+
+  const setupTokens = (accessTokenExpirySeconds, refreshTokenExpirySeconds) => {
+    const now = Math.floor(Date.now() / 1000);
+    KeycloakClient.accessToken = generateFakeJWT({ exp: now + accessTokenExpirySeconds });
+    KeycloakClient.refreshToken = generateFakeJWT({ exp: now + refreshTokenExpirySeconds });
+    originalRefreshToken = KeycloakClient.refreshToken;
+    originalAccessToken = KeycloakClient.accessToken;
+  };
+
+  beforeEach(() => jest.resetAllMocks());
+
+  it('Uses the access token when still valid', async () => {
+    setupTokens(300, 1800);
+    await KeycloakClient.getAccessToken();
+    expect(KeycloakClient.accessToken).toBe(originalAccessToken);
+  });
+
+  it('Refreshes the tokens when the access token is expired and the refresh token is valid', async () => {
+    setupTokens(0, 1800);
+    mockAxiosInstance.post.mockResolvedValue({
+      status: 200,
+      data: { access_token: 'accessToken', refresh_token: 'refreshToken' },
+    });
+    await KeycloakClient.getAccessToken();
+
+    // Note calls[0] is the first call. calls[0][0] is the url, calls[0][1] is the params
+    const callParams = mockAxiosInstance.post.mock.calls[0][1];
+    expect(callParams.get('grant_type')).toBe('refresh_token');
+
+    expect(KeycloakClient.accessToken).toBe('accessToken');
+    expect(KeycloakClient.refreshToken).toBe('refreshToken');
+  });
+
+  it('Requests a new token set when both current tokens are expired', async () => {
+    setupTokens(0, 0);
+    mockAxiosInstance.post.mockResolvedValue({
+      status: 200,
+      data: { access_token: 'accessToken', refresh_token: 'refreshToken' },
+    });
+    await KeycloakClient.getAccessToken();
+
+    const callParams = mockAxiosInstance.post.mock.calls[0][1];
+    expect(callParams.get('grant_type')).toBe('password');
+
+    expect(KeycloakClient.accessToken).toBe('accessToken');
+    expect(KeycloakClient.refreshToken).toBe('refreshToken');
+  });
+
+  it('Resets the refreshing flag when token refresh fails', async () => {
+    setupTokens(0, 1800);
+    mockAxiosInstance.post.mockRejectedValue({
+      status: 500,
+      data: { message: 'Internal Server Error' },
+    });
+    await KeycloakClient.getAccessToken();
+    expect(KeycloakClient.refreshing).toBe(false);
+  });
+
+  it('Successfully refreshes tokens after a previous refresh failure', async () => {
+    setupTokens(0, 1800);
+
+    // Reject once then resolve to new tokens
+    mockAxiosInstance.post
+      .mockRejectedValueOnce({
+        status: 500,
+        data: { message: 'Internal Server Error' },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { access_token: 'accessToken', refresh_token: 'refreshToken' },
+      });
+
+    // On keycloak call failure tokens should not update
+    await KeycloakClient.getAccessToken();
+    expect(KeycloakClient.refreshToken).toBe(originalRefreshToken);
+    expect(KeycloakClient.accessToken).toBe(originalAccessToken);
+
+    // Follow-up call still updates the tokens
+    await KeycloakClient.getAccessToken();
+    expect(KeycloakClient.refreshToken).toBe('refreshToken');
+    expect(KeycloakClient.accessToken).toBe('accessToken');
+  });
+});
+
+describe('Token Initialization', () => {
+  const KeycloakClient = new KeycloakService();
+  KeycloakClient.setEnvironment('dev');
+
+  it('Handles token initialization failure', async () => {
+    mockAxiosInstance.post
+      .mockRejectedValueOnce({
+        status: 500,
+        data: { message: 'Internal Server Error' },
+      })
+      .mockResolvedValueOnce({
+        status: 200,
+        data: { access_token: 'accessToken', refresh_token: 'refreshToken' },
+      });
+
+    // Failed request left tokens in a null state
+    await KeycloakClient.getAccessToken();
+    expect(KeycloakClient.accessToken).toBe(null);
+    expect(KeycloakClient.refreshToken).toBe(null);
+
+    // Follow up request is still able to set them
+    await KeycloakClient.getAccessToken();
+    expect(KeycloakClient.accessToken).toBe('accessToken');
+    expect(KeycloakClient.refreshToken).toBe('refreshToken');
+  });
+});


### PR DESCRIPTION
## Refresh Bug
The `refreshing` flag was not being reset to `false` on error, leading to the access token always being returned. This caused very flaky behaviour where tokens would sporadically be valid due to the following flow:

1. Token refresh fails, `refreshing` flag gets stuck as `true`
2. Follow up calls instantly return the current access token since `refreshing` is `true`
3. Only after the refresh token expires (30 minutes) does the code go into the else block and get a new set of tokens
4. Since the `refreshing` flag is still stuck on `true`, it returns the new access token until the new refresh token expires again. This resulted in successful requests for 5 minutes (access token lifespan) and failed requests for the remaining 25 minutes of the refresh token's lifespan, on repeat.

It will now reset the flag in a finally block so it always runs. For error cases on token fetching I have left it returning the existing tokens and tested that follow up successful requests will still be able to reset them.

## Pipeline
Also adding the always() flag to the helm deploy when the image build succeeds. This is necessary due to the downstream release job only running on merge to main, but still needing to deploy on dev