### PR TITLE
chore: bceid approval

### DIFF
--- a/app/shared/templates/create-bceid-bottom.html
+++ b/app/shared/templates/create-bceid-bottom.html
@@ -1,7 +1,7 @@
 <strong>Next Steps for your integration with BCeID:</strong>
 <p>
-  As you've requested an integration with BCeID, the {{integration.formattedEnvironments}} integrations require approval
-  from the Identity and Information Management (IDIM) team before they can be used.
+  As you have requested an integration with BCeID, each selected environment requires its own approval from the Identity
+  and Information Management (IDIM) team before it can be used.
 </p>
 <ol>
   <li>

--- a/app/shared/templates/helpers.ts
+++ b/app/shared/templates/helpers.ts
@@ -25,13 +25,6 @@ export const processUser = async (user: any) => {
   return user;
 };
 
-const formatEnvironments = (environments: string[] | undefined) => {
-  if (!environments || environments.length === 0) return '';
-  const formattedEnvironments = environments.map((env) => envMap[env].toLowerCase());
-  if (environments.length === 1) return formattedEnvironments[0];
-  return `${formattedEnvironments.slice(0, -1).join(', ')} and ${formattedEnvironments.slice(-1)}`;
-};
-
 export const processRequest = async (integrationOrModel: any) => {
   let integration!: Integration;
   if (integrationOrModel instanceof models.request) {
@@ -65,8 +58,6 @@ export const processRequest = async (integrationOrModel: any) => {
       (!integration.devBceidApproved && integration.environments?.includes('dev')) ||
       (!integration.testBceidApproved && integration.environments?.includes('test')));
 
-  const formattedEnvironments = formatEnvironments(integration.environments);
-
   return {
     ...integration,
     devValidRedirectUris,
@@ -79,7 +70,6 @@ export const processRequest = async (integrationOrModel: any) => {
     accountableEntity,
     browserLoginEnabled,
     waitingBceidApproval,
-    formattedEnvironments,
   };
 };
 


### PR DESCRIPTION
make email message for bceid approvals more generic. Listing environments specifically can be confusing when partially approved