### PR TITLE
fix: bceid approval events

### DIFF
--- a/app/controllers/bc-services-card.ts
+++ b/app/controllers/bc-services-card.ts
@@ -1,14 +1,26 @@
 import axios from 'axios';
+import createHttpError from 'http-errors';
 
 export const getPrivacyZones = async (env: string = 'prod') => {
   let bcscBaseUrl;
   if (env === 'dev') bcscBaseUrl = process.env.BCSC_REGISTRATION_BASE_URL_DEV;
   if (env === 'test') bcscBaseUrl = process.env.BCSC_REGISTRATION_BASE_URL_TEST;
   if (env === 'prod') bcscBaseUrl = process.env.BCSC_REGISTRATION_BASE_URL_PROD;
-  return await axios.get(`${bcscBaseUrl}/oauth2/privacy-zones`).then((res) => res.data);
+  try {
+    const pzResponse = await axios.get(`${bcscBaseUrl}/oauth2/privacy-zones`);
+    return pzResponse.data;
+  } catch (err) {
+    console.error(`Error fetching privacy zones: ${err}`);
+    throw new createHttpError[424]();
+  }
 };
+
 export const getAttributes = async () => {
-  return await axios
-    .get(`${process.env.BCSC_REGISTRATION_BASE_URL_PROD}/oauth2/claim-types`)
-    .then((res) => res.data?.claims_supported);
+  try {
+    const attributesResponse = await axios.get(`${process.env.BCSC_REGISTRATION_BASE_URL_PROD}/oauth2/claim-types`);
+    return attributesResponse.data?.claims_supported;
+  } catch (err) {
+    console.error(`Error fetching bcsc attributes: ${err}`);
+    throw new createHttpError[424]();
+  }
 };

--- a/app/controllers/events.ts
+++ b/app/controllers/events.ts
@@ -40,11 +40,8 @@ export const getEvents = async (
   if (!hasAppPermission(session?.client_roles, appPermissions.ADMIN_DASHBOARD_VIEW_REQUEST_EVENTS)) {
     const approvedKeys = [];
 
-    if (isBceidApprover(session)) {
-      approvedKeys.push('testBceidApproved');
-      approvedKeys.push('devBceidApproved');
-      approvedKeys.push('bceidApproved');
-    }
+    if (isBceidApprover(session)) approvedKeys.push('devBceidApproved', 'testBceidApproved', 'bceidApproved');
+
     if (isGithubApprover(session)) approvedKeys.push('githubApproved');
 
     if (isOTPApprover(session)) approvedKeys.push('otpApproved');

--- a/app/controllers/events.ts
+++ b/app/controllers/events.ts
@@ -40,8 +40,11 @@ export const getEvents = async (
   if (!hasAppPermission(session?.client_roles, appPermissions.ADMIN_DASHBOARD_VIEW_REQUEST_EVENTS)) {
     const approvedKeys = [];
 
-    if (isBceidApprover(session)) approvedKeys.push('bceidApproved');
-
+    if (isBceidApprover(session)) {
+      approvedKeys.push('testBceidApproved');
+      approvedKeys.push('devBceidApproved');
+      approvedKeys.push('bceidApproved');
+    }
     if (isGithubApprover(session)) approvedKeys.push('githubApproved');
 
     if (isOTPApprover(session)) approvedKeys.push('otpApproved');
@@ -51,21 +54,19 @@ export const getEvents = async (
     if (isSocialApprover(session)) approvedKeys.push('socialApproved');
 
     if (approvedKeys.length > 0) {
-      where[Op.or] = [
-        approvedKeys.map((key) => ({
-          details: {
-            [Op.contains]: {
-              changes: [
-                {
-                  rhs: true,
-                  kind: 'E',
-                  path: [key],
-                },
-              ],
-            },
+      where[Op.or] = approvedKeys.map((key) => ({
+        details: {
+          [Op.contains]: {
+            changes: [
+              {
+                rhs: true,
+                kind: 'E',
+                path: [key],
+              },
+            ],
           },
-        })),
-      ];
+        },
+      }));
     }
   }
 

--- a/app/jest-api/25.idp-approver.test.ts
+++ b/app/jest-api/25.idp-approver.test.ts
@@ -179,6 +179,27 @@ describe('IDP Approver', () => {
     expect(restoreRes.status).toEqual(403);
   });
 
+  it('BCeID approver can view bceid approval events for all environments', async () => {
+    createMockAuth(BCEID_ADMIN_IDIR_USERID_01, BCEID_ADMIN_IDIR_EMAIL_01, ['bceid-approver']);
+    const requests = await getRequestsForAdmins();
+
+    const updated = await updateIntegration({ ...requests.body.rows[0], devBceidApproved: true }, true);
+    await updateIntegration({ ...updated.body, testBceidApproved: true }, true);
+
+    const eventsRes = await getEvents(requests.body.rows[0].id);
+    expect(eventsRes.status).toEqual(200);
+    expect(eventsRes.body.count).toEqual(3);
+    expect(eventsRes.body.rows.length).toEqual(3);
+
+    expect(eventsRes.body.rows.some((row: any) => row.details.changes[0].path.includes('bceidApproved'))).toBeTruthy();
+    expect(
+      eventsRes.body.rows.some((row: any) => row.details.changes[0].path.includes('devBceidApproved')),
+    ).toBeTruthy();
+    expect(
+      eventsRes.body.rows.some((row: any) => row.details.changes[0].path.includes('testBceidApproved')),
+    ).toBeTruthy();
+  });
+
   it('BCeID approver can edit/approve/delete owned integrations', async () => {
     createMockAuth(BCEID_ADMIN_IDIR_USERID_01, BCEID_ADMIN_IDIR_EMAIL_01, ['bceid-approver']);
     const bceidApproverIntegration = await buildIntegration({

--- a/app/jest-api/29.bcsc-endpoints.test.ts
+++ b/app/jest-api/29.bcsc-endpoints.test.ts
@@ -1,13 +1,16 @@
 import { createMockAuth } from './mocks/authenticate';
-import { getBcscClaims } from './helpers/modules/bcsc';
-import { getPrivacyZones } from './helpers/modules/bcsc';
+import { getBcscClaims, getPrivacyZones } from './helpers/modules/bcsc';
 import { TEAM_MEMBER_IDIR_EMAIL_01, TEAM_MEMBER_IDIR_USERID_01 } from './helpers/fixtures';
 
-jest.mock('axios', () => {
-  return {
-    get: jest.fn(() => Promise.reject({ status: 500, message: 'Internal Server Error' })),
-  };
-});
+jest.mock('axios', () => ({
+  get: jest.fn(() =>
+    Promise.reject({
+      response: {
+        status: 500,
+      },
+    }),
+  ),
+}));
 
 describe('BCSC data fetching', () => {
   it('Returns 424 when getAttributes upstream call fails with 500', async () => {

--- a/app/jest-api/29.bcsc-endpoints.test.ts
+++ b/app/jest-api/29.bcsc-endpoints.test.ts
@@ -1,0 +1,24 @@
+import { createMockAuth } from './mocks/authenticate';
+import { getBcscClaims } from './helpers/modules/bcsc';
+import { getPrivacyZones } from './helpers/modules/bcsc';
+import { TEAM_MEMBER_IDIR_EMAIL_01, TEAM_MEMBER_IDIR_USERID_01 } from './helpers/fixtures';
+
+jest.mock('axios', () => {
+  return {
+    get: jest.fn(() => Promise.reject({ status: 500, message: 'Internal Server Error' })),
+  };
+});
+
+describe('BCSC data fetching', () => {
+  it('Returns 424 when getAttributes upstream call fails with 500', async () => {
+    createMockAuth(TEAM_MEMBER_IDIR_USERID_01, TEAM_MEMBER_IDIR_EMAIL_01);
+    const response = await getBcscClaims();
+    expect(response.status).toBe(424);
+  });
+
+  it('Returns 424 when getPrivacyZones upstream call fails with 500', async () => {
+    createMockAuth(TEAM_MEMBER_IDIR_USERID_01, TEAM_MEMBER_IDIR_EMAIL_01);
+    const response = await getPrivacyZones();
+    expect(response.status).toBe(424);
+  });
+});

--- a/app/jest-api/helpers/modules/bcsc.ts
+++ b/app/jest-api/helpers/modules/bcsc.ts
@@ -1,6 +1,5 @@
 import { testClient } from '../test-client';
 import { API_BASE_PATH } from '../constants';
-import requestsAllHandler from '@app/pages/api/requests-all';
 import claimsHandler from '@app/pages/api/bc-services-card/claim-types';
 import privacyZoneHandler from '@app/pages/api/bc-services-card/privacy-zones';
 

--- a/app/jest-api/helpers/modules/bcsc.ts
+++ b/app/jest-api/helpers/modules/bcsc.ts
@@ -1,0 +1,13 @@
+import { testClient } from '../test-client';
+import { API_BASE_PATH } from '../constants';
+import requestsAllHandler from '@app/pages/api/requests-all';
+import claimsHandler from '@app/pages/api/bc-services-card/claim-types';
+import privacyZoneHandler from '@app/pages/api/bc-services-card/privacy-zones';
+
+export const getBcscClaims = async () => {
+  return await testClient(claimsHandler).get(`${API_BASE_PATH}/claim-types`).set('Accept', 'application/json');
+};
+
+export const getPrivacyZones = async () => {
+  return await testClient(privacyZoneHandler).get(`${API_BASE_PATH}/privacy-zones`).set('Accept', 'application/json');
+};


### PR DESCRIPTION
- update permissions to allow bceid approvers to fetch dev/test approval events
- add handling to BCSC endpoint callouts and update status code