### PR TITLE
fix: grafana parsing

### DIFF
--- a/app/utils/grafana.ts
+++ b/app/utils/grafana.ts
@@ -84,7 +84,10 @@ export const clientEventsAggregationQuery = async (
   const values = res?.data?.results?.A?.frames[0]?.data?.values;
 
   if (values.length > 0) {
-    result = values[0].map((item: any) => JSON.parse(item));
+    result = values[0].map((item: any) => {
+      if (typeof item === 'string') return JSON.parse(item);
+      else return item;
+    });
   }
 
   return result;

--- a/app/utils/grafana.ts
+++ b/app/utils/grafana.ts
@@ -81,9 +81,9 @@ export const clientEventsAggregationQuery = async (
   };
   const res: any = await axios.post(`${process.env.GRAFANA_API_URL}/ds/query`, query, { headers });
 
-  const values = res?.data?.results?.A?.frames[0]?.data?.values;
+  const values = res?.data?.results?.A?.frames?.[0]?.data?.values;
 
-  if (values.length > 0) {
+  if (Array.isArray(values) && values.length > 0) {
     result = values[0].map((item: any) => {
       if (typeof item === 'string') return JSON.parse(item);
       else return item;


### PR DESCRIPTION
add type check on json parsing of grafana response. After the grafana upgrade it is sending JSON now instead of string. Adding type check to handle either case