### PR TITLE
chore: home url help text

### DIFF
--- a/app/schemas/environment-gold.ts
+++ b/app/schemas/environment-gold.ts
@@ -173,7 +173,7 @@ export default function getSchemas(formData: Integration, session: LoggedInUser 
         type: 'string',
         title: 'Home Page URL',
         tooltip: {
-          content: `URL of the home page of your application. The value of this field MUST point to a valid Web page, and will be presented to end users in BCSC Service Listing, and possibly during authentication.`,
+          content: `URL of the home page of your application. The value of this field must point to a valid Web page. Your selected identity providers may use this in service listings and links to your application.`,
         },
         placeholder: 'e.g. https://example.com',
         default: '',

--- a/app/schemas/environment-gold.ts
+++ b/app/schemas/environment-gold.ts
@@ -173,7 +173,7 @@ export default function getSchemas(formData: Integration, session: LoggedInUser 
         type: 'string',
         title: 'Home Page URL',
         tooltip: {
-          content: `URL of the home page of your application. The value of this field must point to a valid Web page. Your selected identity providers may use this in service listings and links to your application.`,
+          content: `URL of the home page of your application. The value of this field must point to a valid Web page. Your selected identity providers may use this to identify or link to your application.`,
         },
         placeholder: 'e.g. https://example.com',
         default: '',


### PR DESCRIPTION
Make home url field description text more generic, since it can apply to OTP or BCSC.