### PR TITLE
feat: assign privacy zone scope upon selection of otp idp

### DIFF
--- a/app/jest-api/20.bcsc.test.ts
+++ b/app/jest-api/20.bcsc.test.ts
@@ -345,8 +345,8 @@ describe('Build Github Dispatch', () => {
     expect(processedIntegration?.devIdps?.includes('bcservicescard')).toBe(true);
   });
 
-  it('Does not add the idp scope if not in the production idp list', () => {
-    const result = getDefaultClientScopes(
+  it('Does not add the idp scope if not in the production idp list', async () => {
+    const result = await getDefaultClientScopes(
       {
         ...bcscProdIntegration,
         clientId: 'myClient',
@@ -365,8 +365,8 @@ describe('Build Github Dispatch', () => {
     expect(processedIntegration?.prodIdps?.includes('bcservicescard')).toBe(true);
   });
 
-  it('Does add the idp scope if included in the production idp list', () => {
-    const result = getDefaultClientScopes(
+  it('Does add the idp scope if included in the production idp list', async () => {
+    const result = await getDefaultClientScopes(
       {
         ...bcscProdIntegration,
         clientId: 'myClient',

--- a/app/jest-api/27.social.test.ts
+++ b/app/jest-api/27.social.test.ts
@@ -95,8 +95,8 @@ describe('Build Github Dispatch', () => {
     expect(processedIntegration?.devIdps?.includes('social')).toBe(true);
   });
 
-  it('Does not add the idp scopes to production if social is excluded from the production idp list', () => {
-    const result = getDefaultClientScopes(
+  it('Does not add the idp scopes to production if social is excluded from the production idp list', async () => {
+    const result = await getDefaultClientScopes(
       {
         ...socialProdIntegration,
         clientId: 'myClient',
@@ -118,8 +118,8 @@ describe('Build Github Dispatch', () => {
     expect(processedIntegration?.prodIdps?.includes('social')).toBe(true);
   });
 
-  it('Does add the idp scope if included in the production idp list', () => {
-    const result = getDefaultClientScopes(
+  it('Does add the idp scope if included in the production idp list', async () => {
+    const result = await getDefaultClientScopes(
       {
         ...socialProdIntegration,
         clientId: 'myClient',

--- a/app/jest-api/28.otp.test.ts
+++ b/app/jest-api/28.otp.test.ts
@@ -134,8 +134,8 @@ describe('Build Github Dispatch', () => {
     expect(processedIntegration?.devIdps?.includes('otp')).toBe(true);
   });
 
-  it('Does not add the idp scopes to production if otp is excluded from the production idp list', () => {
-    const result = getDefaultClientScopes(
+  it('Does not add the idp scopes to production if otp is excluded from the production idp list', async () => {
+    const result = await getDefaultClientScopes(
       {
         ...otpProdIntegration,
         clientId: 'myClient',
@@ -149,8 +149,8 @@ describe('Build Github Dispatch', () => {
     expect(result.includes('otp')).toBeFalsy();
   });
 
-  it('Does add the idp scope if included in the production idp list', () => {
-    const result = getDefaultClientScopes(
+  it('Does add the idp scope if included in the production idp list', async () => {
+    const result = await getDefaultClientScopes(
       {
         ...otpProdIntegration,
         clientId: 'myClient',

--- a/app/keycloak/integration.ts
+++ b/app/keycloak/integration.ts
@@ -15,7 +15,6 @@ import {
   deleteMapper,
   listClientProtocolMappers,
   manageAdditionalClientRolesMapper,
-  managePpidSamlMapper,
 } from './protocolMappers';
 import { getPrivacyZoneURI } from '@app/utils/bcsc-client';
 
@@ -142,12 +141,9 @@ export const getDefaultClientScopes = async (integration: IntegrationData, envir
     defaultScopes.push(integration?.clientId!);
   }
 
-  if (
-    integration.protocol === 'oidc' &&
-    usesOTP(integration) &&
-    integration[`${environment}Idps` as keyof IntegrationData].includes('otp')
-  ) {
-    const privacyZoneUri = await getPrivacyZoneURI(environment, integration.bcscPrivacyZone!);
+  if (usesOTP(integration) && integration[`${environment}Idps` as keyof IntegrationData].includes('otp')) {
+    let privacyZoneUri = await getPrivacyZoneURI(environment, integration.bcscPrivacyZone!);
+    if (integration.protocol === 'saml') privacyZoneUri = `${privacyZoneUri}-saml`;
     defaultScopes.push(privacyZoneUri);
   }
 
@@ -371,19 +367,6 @@ export const keycloakClient = async (
           '',
           integration.clientId!,
         );
-      }
-
-      if (defaultScopes.includes('otp-saml')) {
-        const privacyZoneUri = await getPrivacyZoneURI(environment, integration.bcscPrivacyZone!);
-        const ppidMapper = protocolMappersForClient.find((mapper) => mapper.name === 'ppid');
-        if (!ppidMapper) {
-          await managePpidSamlMapper(kcAdminClient, client.id!, realm, privacyZoneUri, '');
-        } else {
-          await managePpidSamlMapper(kcAdminClient, client.id!, realm, privacyZoneUri, ppidMapper?.id!);
-        }
-      } else {
-        const ppidMapper = protocolMappersForClient.find((mapper) => mapper.name === 'ppid');
-        if (ppidMapper) await deleteMapper(kcAdminClient, client.id!, realm, ppidMapper.id!);
       }
     } else if (!protocolMappersForClient.find((mapper) => mapper.name === 'team')) {
       await createTeamMapper(kcAdminClient, client.id!, realm, String(integration.teamId));

--- a/app/keycloak/integration.ts
+++ b/app/keycloak/integration.ts
@@ -16,6 +16,7 @@ import {
   deleteMapper,
   listClientProtocolMappers,
   manageAdditionalClientRolesMapper,
+  managePpidSamlMapper,
 } from './protocolMappers';
 import { getPrivacyZoneURI } from '@app/utils/bcsc-client';
 
@@ -116,7 +117,7 @@ export const samlClientProfile = (
 /** Client scopes to add when social is selected. */
 export const socialIdps = ['google', 'microsoft', 'apple'];
 
-export const getDefaultClientScopes = (integration: IntegrationData, environment: string) => {
+export const getDefaultClientScopes = async (integration: IntegrationData, environment: string) => {
   let defaultScopes = integration.protocol === 'oidc' ? ['common', 'profile', 'email'] : ['common'];
 
   // BCSC and Social client scopes are not the same as the IDP name and need to be handled individually.
@@ -141,6 +142,16 @@ export const getDefaultClientScopes = (integration: IntegrationData, environment
   ) {
     defaultScopes.push(integration?.clientId!);
   }
+
+  if (
+    integration.protocol === 'oidc' &&
+    usesOTP(integration) &&
+    integration[`${environment}Idps` as keyof IntegrationData].includes('otp')
+  ) {
+    const privacyZoneUri = await getPrivacyZoneURI(environment, integration.bcscPrivacyZone!);
+    defaultScopes.push(privacyZoneUri);
+  }
+
   return defaultScopes;
 };
 
@@ -214,7 +225,7 @@ export const keycloakClient = async (
       clientData.baseUrl = homeUri ?? '';
     }
 
-    const defaultScopes = getDefaultClientScopes(integration, environment);
+    const defaultScopes = await getDefaultClientScopes(integration, environment);
     if (clients.length === 0) {
       // if client does not exist then just create client
       client = await kcAdminClient.clients.create({ realm, ...clientData });
@@ -363,20 +374,13 @@ export const keycloakClient = async (
         );
       }
 
-      if (defaultScopes.includes('otp') || defaultScopes.includes('otp-saml')) {
+      if (defaultScopes.includes('otp-saml')) {
         const privacyZoneUri = await getPrivacyZoneURI(environment, integration.bcscPrivacyZone!);
         const ppidMapper = protocolMappersForClient.find((mapper) => mapper.name === 'ppid');
         if (!ppidMapper) {
-          await managePpidMapper(kcAdminClient, integration.protocol || 'oidc', client.id!, realm, privacyZoneUri, '');
+          await managePpidSamlMapper(kcAdminClient, client.id!, realm, privacyZoneUri, '');
         } else {
-          await managePpidMapper(
-            kcAdminClient,
-            integration.protocol || 'oidc',
-            client.id!,
-            realm,
-            privacyZoneUri,
-            ppidMapper?.id!,
-          );
+          await managePpidSamlMapper(kcAdminClient, client.id!, realm, privacyZoneUri, ppidMapper?.id!);
         }
       } else {
         const ppidMapper = protocolMappersForClient.find((mapper) => mapper.name === 'ppid');

--- a/app/keycloak/integration.ts
+++ b/app/keycloak/integration.ts
@@ -10,7 +10,6 @@ import { getByRequestId } from '@app/queries/bcsc-client';
 import {
   createAccessTokenAudMapper,
   createClientRolesMapper,
-  managePpidMapper,
   createPreferredUsernameMapper,
   createTeamMapper,
   deleteMapper,

--- a/app/keycloak/protocolMappers.ts
+++ b/app/keycloak/protocolMappers.ts
@@ -44,51 +44,6 @@ export const createClientRolesMapper = async (
   }
 };
 
-export const managePpidSamlMapper = async (
-  kcAdminClient: KeycloakAdminClient,
-  clientId: string,
-  realm: string,
-  privacyZoneUri: string,
-  mapperId: string,
-) => {
-  let config: ProtocolMapperRepresentation = { name: 'ppid' };
-  try {
-    config = {
-      ...config,
-      protocol: 'saml',
-      protocolMapper: 'saml-ppid-nameid-mapper',
-      config: {
-        'nameid.format': 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-        privacy_zone: privacyZoneUri,
-      },
-    };
-
-    if (!mapperId) {
-      await kcAdminClient.clients.addProtocolMapper(
-        {
-          id: clientId,
-          realm,
-        },
-        config,
-      );
-    } else {
-      await kcAdminClient.clients.updateProtocolMapper(
-        {
-          id: clientId,
-          realm,
-          mapperId,
-        },
-        {
-          ...config,
-          id: mapperId,
-        },
-      );
-    }
-  } catch (err) {
-    throw new Error('Failed to create ppid mapper');
-  }
-};
-
 export const createTeamMapper = async (
   kcAdminClient: KeycloakAdminClient,
   clientId: string,

--- a/app/keycloak/protocolMappers.ts
+++ b/app/keycloak/protocolMappers.ts
@@ -44,9 +44,8 @@ export const createClientRolesMapper = async (
   }
 };
 
-export const managePpidMapper = async (
+export const managePpidSamlMapper = async (
   kcAdminClient: KeycloakAdminClient,
-  protocol: string,
   clientId: string,
   realm: string,
   privacyZoneUri: string,
@@ -54,32 +53,15 @@ export const managePpidMapper = async (
 ) => {
   let config: ProtocolMapperRepresentation = { name: 'ppid' };
   try {
-    if (protocol === 'oidc') {
-      config = {
-        ...config,
-        protocol: 'openid-connect',
-        protocolMapper: 'oidc-idp-ppid-mapper',
-        config: {
-          'access.token.claim': 'true',
-          'claim.name': 'sub',
-          'id.token.claim': 'true',
-          'introspection.token.claim': 'true',
-          'lightweight.claim': 'false',
-          'userinfo.token.claim': 'true',
-          privacy_zone: privacyZoneUri,
-        },
-      };
-    } else {
-      config = {
-        ...config,
-        protocol: 'saml',
-        protocolMapper: 'saml-ppid-nameid-mapper',
-        config: {
-          'nameid.format': 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
-          privacy_zone: privacyZoneUri,
-        },
-      };
-    }
+    config = {
+      ...config,
+      protocol: 'saml',
+      protocolMapper: 'saml-ppid-nameid-mapper',
+      config: {
+        'nameid.format': 'urn:oasis:names:tc:SAML:2.0:nameid-format:persistent',
+        privacy_zone: privacyZoneUri,
+      },
+    };
 
     if (!mapperId) {
       await kcAdminClient.clients.addProtocolMapper(


### PR DESCRIPTION
This change removes addition of ppid mapper to a client dedicated scopes and instead assigns privacy zone scope that already includes PPID mapper. This change is being made to support SDX user flow.