### PR TITLE
chore: redirect uri validation

### DIFF
--- a/app/jest-api/30.web-origins.test.ts
+++ b/app/jest-api/30.web-origins.test.ts
@@ -73,6 +73,18 @@ describe('WebOrigins with scheme://* redirect URIs', () => {
       expect(profile.webOrigins).not.toContain('*');
       expect(profile.webOrigins).toContain('+');
     });
+
+    it('does not include * for non-http/https schemes (e.g. custom deep links)', () => {
+      const integration = {
+        ...baseIntegration,
+        publicAccess: true,
+        devValidRedirectUris: ['myapp://*'],
+      } as IntegrationData;
+
+      const profile = openIdClientProfile(integration, 'dev', authFlows);
+
+      expect(profile.webOrigins).not.toContain('*');
+    });
   });
 
   describe('public client in test', () => {

--- a/app/jest-api/30.web-origins.test.ts
+++ b/app/jest-api/30.web-origins.test.ts
@@ -49,6 +49,18 @@ describe('WebOrigins with scheme://* redirect URIs', () => {
       expect(profile.webOrigins).toContain('+');
     });
 
+    it('includes * in webOrigins when https://*/path is a redirect URI', () => {
+      const integration = {
+        ...baseIntegration,
+        publicAccess: true,
+        devValidRedirectUris: ['https://*/some-specific-path'],
+      } as IntegrationData;
+
+      const profile = openIdClientProfile(integration, 'dev', authFlows);
+
+      expect(profile.webOrigins).toContain('*');
+    });
+
     it('does not include * when no scheme://* redirect URI is present', () => {
       const integration = {
         ...baseIntegration,

--- a/app/jest-api/30.web-origins.test.ts
+++ b/app/jest-api/30.web-origins.test.ts
@@ -1,0 +1,109 @@
+import { openIdClientProfile } from '@app/keycloak/integration';
+import { IntegrationData } from '@app/shared/interfaces';
+
+jest.mock('@app/keycloak/adminClient', () => ({}));
+jest.mock('@app/controllers/requests', () => ({
+  createBCSCIntegration: jest.fn(),
+  deleteBCSCIntegration: jest.fn(),
+}));
+jest.mock('@app/helpers/integration', () => ({
+  usesBcServicesCard: jest.fn(),
+  usesOTP: jest.fn(),
+}));
+jest.mock('@app/queries/bcsc-client', () => ({
+  getByRequestId: jest.fn(),
+}));
+jest.mock('@app/keycloak/protocolMappers', () => ({
+  createAccessTokenAudMapper: jest.fn(),
+  createClientRolesMapper: jest.fn(),
+  createPreferredUsernameMapper: jest.fn(),
+  createTeamMapper: jest.fn(),
+  deleteMapper: jest.fn(),
+  listClientProtocolMappers: jest.fn(),
+  manageAdditionalClientRolesMapper: jest.fn(),
+}));
+jest.mock('@app/utils/bcsc-client', () => ({
+  getPrivacyZoneURI: jest.fn(),
+}));
+
+const baseIntegration: Partial<IntegrationData> = {
+  clientId: 'test-client',
+  authType: 'browser-login',
+  browserFlowOverride: '',
+};
+
+const authFlows: any[] = [];
+
+describe('WebOrigins with scheme://* redirect URIs', () => {
+  describe('public client in dev', () => {
+    it('includes * in webOrigins when https://* is a redirect URI', () => {
+      const integration = {
+        ...baseIntegration,
+        publicAccess: true,
+        devValidRedirectUris: ['https://*', 'https://example.com/*'],
+      } as IntegrationData;
+
+      const profile = openIdClientProfile(integration, 'dev', authFlows);
+
+      expect(profile.webOrigins).toContain('*');
+      expect(profile.webOrigins).toContain('+');
+    });
+
+    it('does not include * when no scheme://* redirect URI is present', () => {
+      const integration = {
+        ...baseIntegration,
+        publicAccess: true,
+        devValidRedirectUris: ['https://example.com/*', 'https://app.example.com/callback'],
+      } as IntegrationData;
+
+      const profile = openIdClientProfile(integration, 'dev', authFlows);
+
+      expect(profile.webOrigins).not.toContain('*');
+      expect(profile.webOrigins).toContain('+');
+    });
+  });
+
+  describe('public client in test', () => {
+    it('includes * in webOrigins when https://* is a redirect URI', () => {
+      const integration = {
+        ...baseIntegration,
+        publicAccess: true,
+        testValidRedirectUris: ['https://*'],
+      } as IntegrationData;
+
+      const profile = openIdClientProfile(integration, 'test', authFlows);
+
+      expect(profile.webOrigins).toContain('*');
+    });
+  });
+
+  describe('confidential client in dev', () => {
+    it('never includes * in webOrigins even with https://* redirect URI', () => {
+      const integration = {
+        ...baseIntegration,
+        publicAccess: false,
+        devValidRedirectUris: ['https://*'],
+      } as IntegrationData;
+
+      const profile = openIdClientProfile(integration, 'dev', authFlows);
+
+      expect(profile.webOrigins).not.toContain('*');
+      expect(profile.webOrigins).toContain('+');
+    });
+  });
+
+  describe('public client in prod', () => {
+    it('never includes * in webOrigins regardless of redirect URIs', () => {
+      const integration = {
+        ...baseIntegration,
+        publicAccess: true,
+        // prod validation blocks https://* but we test the safeguard directly
+        prodValidRedirectUris: ['https://*'],
+      } as IntegrationData;
+
+      const profile = openIdClientProfile(integration, 'prod', authFlows);
+
+      expect(profile.webOrigins).not.toContain('*');
+    });
+  });
+});

--- a/app/jest/helpers.test.ts
+++ b/app/jest/helpers.test.ts
@@ -8,6 +8,17 @@ describe('kecloak URIs', () => {
     expect(isValidKeycloakURIDev(':/')).toBe(false);
     expect(isValidKeycloakURIDev('//')).toBe(false);
     expect(isValidKeycloakURIDev('example://*')).toBe(true);
+
+    // Keycloak 26.6.4: wildcards in hostnames are no longer valid
+    expect(isValidKeycloakURIDev('https://example.com*')).toBe(false);
+    expect(isValidKeycloakURIDev('https://*.example.com')).toBe(false);
+    expect(isValidKeycloakURIDev('https://exam*ple.com')).toBe(false);
+    // full hostname wildcard (scheme://*) is still accepted
+    expect(isValidKeycloakURIDev('https://*')).toBe(true);
+    // wildcard in path is still accepted
+    expect(isValidKeycloakURIDev('https://example.com/*')).toBe(true);
+    expect(isValidKeycloakURIDev('https://example.com/path*')).toBe(true);
+
     expect(isValidKeycloakURIProd('*')).toBe(false);
 
     expect(isValidKeycloakURIProd('http://a')).toBe(true);

--- a/app/keycloak/integration.ts
+++ b/app/keycloak/integration.ts
@@ -39,6 +39,14 @@ export const openIdClientProfile = (
   const validRedirectUris = integration[`${environment}ValidRedirectUris` as keyof IntegrationData] || [];
   const pkceCodeChallengeMethod = integration.publicAccess ? 'S256' : '';
 
+  // For public clients in dev/test, scheme://* in redirect URIs doesn't map to a valid
+  // CORS origin via '+', so explicitly add '*' to cover it.
+  const hasFullHostnameWildcard =
+    integration.publicAccess &&
+    environment !== 'prod' &&
+    (validRedirectUris as string[]).some((uri) => /^[a-zA-Z][a-zA-Z-.]*:\/\/\*$/.test(uri));
+  const webOrigins = (validRedirectUris as string[]).concat('+').concat(hasFullHostnameWildcard ? ['*'] : []);
+
   let oidcClient: ClientRepresentation = {
     clientId: integration.clientId,
     name: clientName || integration.clientId,
@@ -60,7 +68,7 @@ export const openIdClientProfile = (
     serviceAccountsEnabled: ['service-account', 'both'].includes(integration?.authType!),
     publicClient: integration.publicAccess || false,
     redirectUris: validRedirectUris,
-    webOrigins: validRedirectUris.concat('+'),
+    webOrigins,
     fullScopeAllowed: false,
     authenticationFlowBindingOverrides: {
       browser: authFlows.find((flow) => flow.alias === integration.browserFlowOverride)?.id || '',

--- a/app/keycloak/integration.ts
+++ b/app/keycloak/integration.ts
@@ -44,7 +44,7 @@ export const openIdClientProfile = (
   const hasFullHostnameWildcard =
     integration.publicAccess &&
     environment !== 'prod' &&
-    (validRedirectUris as string[]).some((uri) => /^[a-zA-Z][a-zA-Z-.]*:\/\/\*(\/|$)/.test(uri));
+    (validRedirectUris as string[]).some((uri) => /^https?:\/\/\*(\/|$)/.test(uri));
   const webOrigins = (validRedirectUris as string[]).concat('+').concat(hasFullHostnameWildcard ? ['*'] : []);
 
   let oidcClient: ClientRepresentation = {

--- a/app/keycloak/integration.ts
+++ b/app/keycloak/integration.ts
@@ -44,7 +44,7 @@ export const openIdClientProfile = (
   const hasFullHostnameWildcard =
     integration.publicAccess &&
     environment !== 'prod' &&
-    (validRedirectUris as string[]).some((uri) => /^[a-zA-Z][a-zA-Z-.]*:\/\/\*$/.test(uri));
+    (validRedirectUris as string[]).some((uri) => /^[a-zA-Z][a-zA-Z-.]*:\/\/\*(\/|$)/.test(uri));
   const webOrigins = (validRedirectUris as string[]).concat('+').concat(hasFullHostnameWildcard ? ['*'] : []);
 
   let oidcClient: ClientRepresentation = {

--- a/app/utils/validate.ts
+++ b/app/utils/validate.ts
@@ -12,7 +12,7 @@ const isValidKeycloakURI = (isProd: boolean, uri: string) => {
     if (uri.match(/\s|#/)) return false;
     if (isProd) {
       if (!uri.match(/^[a-zA-Z][a-zA-Z-\.]*:\/\/([^*\s]+\/\S*|[^*\s]*[^*\s]$)/)) return false;
-    } else if (!uri.match(/^[a-zA-Z][a-zA-Z-.]*:\/\/\S+/)) {
+    } else if (!uri.match(/^[a-zA-Z][a-zA-Z-.]*:\/\/(\*|[^*\s/]+)(\/\S*)?$/)) {
       return false;
     }
     return true;


### PR DESCRIPTION
update validations to match the keycloak 26.6.4 hostname limitations