### PR TITLE
feat: bcsc exclusion list

### DIFF
--- a/app/controllers/requests.ts
+++ b/app/controllers/requests.ts
@@ -560,9 +560,9 @@ export const updateRequest = async (
       throw new createHttpError[400]('Invalid IDP Selection');
     }
 
-    const allowOtpIdp = await doSkipPrivacyZoneScope(originalData.id);
+    const isBcscExcludedRequest = await doSkipPrivacyZoneScope(originalData.id);
 
-    if (allowOtpIdp && usesOTP(current)) {
+    if (isBcscExcludedRequest && usesOTP(current)) {
       throw new createHttpError[400](
         'OTP IDP is not allowed for this integration as it is part of BCSC exclusion list',
       );

--- a/app/controllers/requests.ts
+++ b/app/controllers/requests.ts
@@ -94,6 +94,7 @@ import axios from 'axios';
 import { getKeycloakClientsByEnv } from './keycloak';
 import { hasAppPermission, appPermissions } from '@app/utils/authorize';
 import { Event } from '@app/interfaces/Event';
+import { doSkipPrivacyZoneScope } from '@app/queries/custom-requests';
 
 const app_env = process.env.NEXT_PUBLIC_APP_ENV || 'development';
 
@@ -532,6 +533,7 @@ export const updateRequest = async (
     }
 
     const allowedData = sanitizeRequest(session, rest, isMerged);
+
     assign(current, allowedData);
 
     const mergedData = getCurrentValue();
@@ -556,6 +558,14 @@ export const updateRequest = async (
     });
     if (!validIDPSelection) {
       throw new createHttpError[400]('Invalid IDP Selection');
+    }
+
+    const allowOtpIdp = await doSkipPrivacyZoneScope(originalData.id);
+
+    if (allowOtpIdp && usesOTP(current)) {
+      throw new createHttpError[400](
+        'OTP IDP is not allowed for this integration as it is part of BCSC exclusion list',
+      );
     }
 
     // IDP approvers are not allowed to update other fields except approved flag if request doesn't belong to them

--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -291,7 +291,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
 
   const isBcscExcluded = async () => {
     const [bcscExcluded] = await isRequestBcscExcluded(request as Integration);
-    setBcscExcluded(bcscExcluded || false);
+    setBcscExcluded(!!bcscExcluded);
   };
 
   useEffect(() => {

--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -290,7 +290,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
   };
 
   const isBcscExcluded = async () => {
-    const [bcscExcluded] = await isRequestBcscExcluded(request as Integration);
+    const [bcscExcluded] = await isRequestBcscExcluded(request?.id!);
     setBcscExcluded(!!bcscExcluded);
   };
 

--- a/app/form-components/FormTemplate.tsx
+++ b/app/form-components/FormTemplate.tsx
@@ -28,7 +28,7 @@ import { getSchemas } from 'schemas';
 import { Integration } from 'interfaces/Request';
 import { Team, LoggedInUser } from 'interfaces/team';
 import CancelConfirmModal from 'page-partials/edit-request/CancelConfirmModal';
-import { createRequest, updateRequest } from 'services/request';
+import { createRequest, isRequestBcscExcluded, updateRequest } from 'services/request';
 import { SurveyContext } from '@app/utils/context';
 import { defaultStandardRealmSettings, docusaurusURL } from '@app/utils/constants';
 import { BcscAttribute, BcscPrivacyZone } from '@app/interfaces/types';
@@ -164,6 +164,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
     test: defaultStandardRealmSettings,
     prod: defaultStandardRealmSettings,
   });
+  const [bcscExcluded, setBcscExcluded] = useState(false);
 
   const surveyContext = useContext(SurveyContext);
 
@@ -288,11 +289,17 @@ function FormTemplate({ currentUser, request, alert }: Props) {
     setSchemas(schemas);
   };
 
+  const isBcscExcluded = async () => {
+    const [bcscExcluded] = await isRequestBcscExcluded(request as Integration);
+    setBcscExcluded(bcscExcluded || false);
+  };
+
   useEffect(() => {
     loadTeams();
     loadBcscPrivacyZones();
     loadBcscAttributes();
     loadDefaultSessionSettings();
+    isBcscExcluded();
   }, []);
 
   // Clear other details when other is unselected
@@ -337,6 +344,7 @@ function FormTemplate({ currentUser, request, alert }: Props) {
     teams,
     schemas,
     defaultSessionSettings,
+    bcscExcluded,
   });
 
   const handleFormSubmit = async () => {

--- a/app/form-components/widgets/TooltipIDPCheckboxesWidget.tsx
+++ b/app/form-components/widgets/TooltipIDPCheckboxesWidget.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import clsx from 'clsx';
 import InfoOverlay from 'components/InfoOverlay';
 import styled from 'styled-components';
@@ -33,16 +32,15 @@ function deselectValue(value: string, selected: string[]) {
  */
 function TooltipIDPCheckboxesWidget(props: WidgetProps) {
   const { id, disabled, options, value, autofocus = false, readonly, onChange, schema } = props;
-  const { enumOptions, enumDisabled, enumHidden, inline = false } = options;
+  const { enumOptions, idpsDisabled = [], enumHidden, inline = false } = options;
   const { tooltips, warningMessage } = schema as RJSFSchema & {
     tooltips: { content: string; hide?: number; alpha?: boolean }[];
     warningMessage: string;
   };
 
   const eOptions = Array.isArray(enumOptions) ? enumOptions : [];
-  const eDisabled = Array.isArray(enumDisabled) ? enumDisabled : [];
+  const eDisabled = Array.isArray(idpsDisabled) ? idpsDisabled.map((item) => item.idp) : [];
   const eHidden = Array.isArray(enumHidden) ? enumHidden : [];
-  const formData = props.formContext.formData;
 
   return (
     <div className="checkboxes" id={id}>
@@ -72,6 +70,10 @@ function TooltipIDPCheckboxesWidget(props: WidgetProps) {
             &nbsp;
             {tooltips[index]?.alpha && <AlphaTag>alpha</AlphaTag>}
             {tooltips[index] && <InfoOverlay {...tooltips[index]} />}
+            &nbsp;
+            {eDisabled.length > 0 && Array.isArray(idpsDisabled) && (
+              <span style={{ color: 'red' }}>{idpsDisabled.find((item) => item.idp === option.value)?.reason}</span>
+            )}
           </span>
         );
 

--- a/app/form-components/widgets/TooltipIDPCheckboxesWidget.tsx
+++ b/app/form-components/widgets/TooltipIDPCheckboxesWidget.tsx
@@ -42,6 +42,11 @@ function TooltipIDPCheckboxesWidget(props: WidgetProps) {
   const eDisabled = Array.isArray(idpsDisabled) ? idpsDisabled.map((item) => item.idp) : [];
   const eHidden = Array.isArray(enumHidden) ? enumHidden : [];
 
+  const getReasonForDisabled = (idp: string) => {
+    const disabledItem = (idpsDisabled as Array<{ idp: string; reason: string }>).find((item) => item.idp === idp);
+    return disabledItem ? disabledItem.reason : '';
+  };
+
   return (
     <div className="checkboxes" id={id}>
       {eOptions.map((option, index) => {
@@ -71,8 +76,8 @@ function TooltipIDPCheckboxesWidget(props: WidgetProps) {
             {tooltips[index]?.alpha && <AlphaTag>alpha</AlphaTag>}
             {tooltips[index] && <InfoOverlay {...tooltips[index]} />}
             &nbsp;
-            {eDisabled.length > 0 && Array.isArray(idpsDisabled) && (
-              <span style={{ color: 'red' }}>{idpsDisabled.find((item) => item.idp === option.value)?.reason}</span>
+            {itemDisabled && getReasonForDisabled(option.value) !== '' && (
+              <span style={{ color: 'red' }}>{getReasonForDisabled(option.value)}</span>
             )}
           </span>
         );

--- a/app/jest/axe.test.tsx
+++ b/app/jest/axe.test.tsx
@@ -27,6 +27,7 @@ jest.mock('services/request', () => {
     getRequestAll: jest.fn(() => []),
     getTeamIntegrations: jest.fn(() => []),
     getRequests: jest.fn(() => []),
+    isRequestBcscExcluded: jest.fn(() => Promise.resolve([false, null])),
   };
 });
 

--- a/app/jest/form.test.tsx
+++ b/app/jest/form.test.tsx
@@ -8,7 +8,6 @@ import { defaultStandardRealmSettings, errorMessages } from '../utils/constants'
 import { sampleRequest } from './samples/integrations';
 import { MAX_IDLE_SECONDS, MAX_LIFETIME_SECONDS } from '@app/utils/validate';
 import userEvent from '@testing-library/user-event';
-import { debug } from 'jest-preview';
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),

--- a/app/jest/form.test.tsx
+++ b/app/jest/form.test.tsx
@@ -18,6 +18,7 @@ jest.mock('services/request', () => {
     createRequest: jest.fn(),
     updateRequest: jest.fn(() => Promise.resolve([{}, null])),
     getRequest: jest.fn(),
+    isRequestBcscExcluded: jest.fn(() => Promise.resolve([false, null])),
   };
 });
 

--- a/app/jest/form.test.tsx
+++ b/app/jest/form.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import FormTemplate from 'form-components/FormTemplate';
-import { updateRequest } from 'services/request';
+import { isRequestBcscExcluded, updateRequest } from 'services/request';
 import { Integration } from 'interfaces/Request';
 import { fetchDefaultSessionSettings } from 'services/keycloak';
 import { setUpRouter } from './utils/setup';
@@ -8,6 +8,7 @@ import { defaultStandardRealmSettings, errorMessages } from '../utils/constants'
 import { sampleRequest } from './samples/integrations';
 import { MAX_IDLE_SECONDS, MAX_LIFETIME_SECONDS } from '@app/utils/validate';
 import userEvent from '@testing-library/user-event';
+import { debug } from 'jest-preview';
 
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
@@ -1385,5 +1386,48 @@ describe('One Time Passcode IDP', () => {
     fireEvent.click(sandbox.developmentBox);
     expect(screen.queryByTestId('root_devHomePageUri_title')).not.toBeNull();
     expect(screen.getByText('Please enter a valid URI')).toBeInTheDocument();
+  });
+});
+
+describe('BCSC Excluded Clients', () => {
+  const defaultRender = {
+    id: 0,
+    serviceType: 'gold',
+    status: 'draft',
+    environments: ['dev', 'test', 'prod'],
+  };
+  const userSession = { email: 'user-session@gov.bc.ca', client_roles: ['sso-admin'] };
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.NEXT_PUBLIC_INCLUDE_OTP = 'true';
+  });
+
+  it('Does not disable OTP IDP when request is not in the BCSC exclusion list', async () => {
+    const { queryByText } = setUpRender(defaultRender, userSession);
+
+    fireEvent.click(sandbox.basicInfoBox);
+    await waitFor(() => {
+      const checkbox = queryByText('One Time Passcode')?.parentElement?.querySelector(
+        "input[type='checkbox']",
+      ) as HTMLInputElement;
+      expect(checkbox).toBeTruthy();
+      expect(checkbox).not.toBeDisabled();
+    });
+  });
+
+  it('Disables OTP IDP when request is in the BCSC exclusion list', async () => {
+    const mockedIsRequestBcscExcluded = isRequestBcscExcluded as jest.MockedFunction<typeof isRequestBcscExcluded>;
+    mockedIsRequestBcscExcluded.mockResolvedValue([true, null]);
+    const { queryByText } = setUpRender(defaultRender, userSession);
+
+    fireEvent.click(sandbox.basicInfoBox);
+    await waitFor(() => {
+      const checkbox = queryByText('One Time Passcode')?.parentElement?.querySelector(
+        "input[type='checkbox']",
+      ) as HTMLInputElement;
+      expect(checkbox).toBeTruthy();
+      expect(checkbox).toBeDisabled();
+      expect(screen.getByText('Disabled as client is in bc services card exclusion list')).toBeInTheDocument();
+    });
   });
 });

--- a/app/jest/request.test.tsx
+++ b/app/jest/request.test.tsx
@@ -14,6 +14,7 @@ jest.mock('services/request', () => {
     createRequest: jest.fn(() => successResponse),
     updateRequest: jest.fn(() => successResponse),
     getRequest: jest.fn(() => successResponse),
+    isRequestBcscExcluded: jest.fn(() => Promise.resolve([false, null])),
   };
 });
 

--- a/app/keycloak/integration.ts
+++ b/app/keycloak/integration.ts
@@ -17,6 +17,7 @@ import {
   manageAdditionalClientRolesMapper,
 } from './protocolMappers';
 import { getPrivacyZoneURI } from '@app/utils/bcsc-client';
+import { doSkipPrivacyZoneScope } from '@app/queries/custom-requests';
 
 const realm = 'standard';
 
@@ -149,7 +150,10 @@ export const getDefaultClientScopes = async (integration: IntegrationData, envir
     defaultScopes.push(integration?.clientId!);
   }
 
-  if (usesOTP(integration) && integration[`${environment}Idps` as keyof IntegrationData].includes('otp')) {
+  if (
+    !(await doSkipPrivacyZoneScope(integration.id!)) &&
+    ['bcservicescard', 'otp'].some((idp) => integration[`${environment}Idps` as keyof IntegrationData].includes(idp))
+  ) {
     let privacyZoneUri = await getPrivacyZoneURI(environment, integration.bcscPrivacyZone!);
     if (integration.protocol === 'saml') privacyZoneUri = `${privacyZoneUri}-saml`;
     defaultScopes.push(privacyZoneUri);

--- a/app/pages/api/requests/[id]/is-bcsc-excluded.ts
+++ b/app/pages/api/requests/[id]/is-bcsc-excluded.ts
@@ -14,9 +14,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
 
       const { id } = req.query || {};
 
-      return res
-        .status(200)
-        .json({ success: true, message: await doSkipPrivacyZoneScope(Number.parseInt(id as string)) });
+      const requestId = Number(id);
+      if (!Number.isFinite(requestId)) {
+        return res.status(400).json({ success: false, message: 'invalid request id' });
+      }
+
+      return res.status(200).json({ success: true, message: await doSkipPrivacyZoneScope(requestId) });
     } else {
       res.setHeader('Allow', ['GET']);
       res.status(405).end(`Method ${req.method} Not Allowed`);

--- a/app/pages/api/requests/[id]/is-bcsc-excluded.ts
+++ b/app/pages/api/requests/[id]/is-bcsc-excluded.ts
@@ -4,19 +4,24 @@ import { doSkipPrivacyZoneScope } from '@app/queries/custom-requests';
 import { processUserSession } from '@app/controllers/user';
 import { Session } from '@app/shared/interfaces';
 import { authenticate } from '@app/utils/authenticate';
+import { getAllowedRequest } from '@app/queries/request';
 
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   try {
     if (req.method === 'GET') {
       const userSession = await authenticate(req.headers);
       if (!userSession) return res.status(401).json({ success: false, message: 'not authorized' });
-      await processUserSession(userSession as Session);
+      const { session } = await processUserSession(userSession as Session);
 
       const { id } = req.query || {};
-
       const requestId = Number(id);
       if (!Number.isFinite(requestId)) {
         return res.status(400).json({ success: false, message: 'invalid request id' });
+      }
+
+      const userRequest = await getAllowedRequest(session, requestId);
+      if (!userRequest) {
+        return res.status(403).send('forbidden');
       }
 
       return res.status(200).json({ success: true, message: await doSkipPrivacyZoneScope(requestId) });

--- a/app/pages/api/requests/[id]/is-bcsc-excluded.ts
+++ b/app/pages/api/requests/[id]/is-bcsc-excluded.ts
@@ -1,0 +1,27 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { handleError } from '@app/utils/helpers';
+import { doSkipPrivacyZoneScope } from '@app/queries/custom-requests';
+import { processUserSession } from '@app/controllers/user';
+import { Session } from '@app/shared/interfaces';
+import { authenticate } from '@app/utils/authenticate';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  try {
+    if (req.method === 'GET') {
+      const userSession = await authenticate(req.headers);
+      if (!userSession) return res.status(401).json({ success: false, message: 'not authorized' });
+      await processUserSession(userSession as Session);
+
+      const { id } = req.query || {};
+
+      return res
+        .status(200)
+        .json({ success: true, message: await doSkipPrivacyZoneScope(Number.parseInt(id as string)) });
+    } else {
+      res.setHeader('Allow', ['GET']);
+      res.status(405).end(`Method ${req.method} Not Allowed`);
+    }
+  } catch (error) {
+    handleError(res, error);
+  }
+}

--- a/app/queries/custom-requests.ts
+++ b/app/queries/custom-requests.ts
@@ -1,11 +1,12 @@
 import { models } from '@app/shared/sequelize/models/models';
+import { Op } from 'sequelize/lib/operators';
 
 export const doSkipPrivacyZoneScope = async (requestId: number) => {
   const customRequest = await models.customRequest.findOne({
     where: {
       requestId: requestId,
       conditions: {
-        skipPrivacyZoneScope: true,
+        [Op.contains]: { skipPrivacyZoneScope: true },
       },
     },
   });

--- a/app/queries/custom-requests.ts
+++ b/app/queries/custom-requests.ts
@@ -1,0 +1,15 @@
+import { models } from '@app/shared/sequelize/models/models';
+
+export const doSkipPrivacyZoneScope = async (requestId: number) => {
+  const customRequest = await models.customRequest.findOne({
+    where: {
+      requestId: requestId,
+    },
+  });
+
+  if (customRequest?.conditions?.skipPrivacyZoneScope) {
+    return true;
+  }
+
+  return false;
+};

--- a/app/queries/custom-requests.ts
+++ b/app/queries/custom-requests.ts
@@ -1,10 +1,10 @@
 import { models } from '@app/shared/sequelize/models/models';
-import { Op } from 'sequelize/lib/operators';
+import { Op } from 'sequelize';
 
 export const doSkipPrivacyZoneScope = async (requestId: number) => {
   const customRequest = await models.customRequest.findOne({
     where: {
-      requestId: requestId,
+      requestId,
       conditions: {
         [Op.contains]: { skipPrivacyZoneScope: true },
       },

--- a/app/queries/custom-requests.ts
+++ b/app/queries/custom-requests.ts
@@ -4,10 +4,13 @@ export const doSkipPrivacyZoneScope = async (requestId: number) => {
   const customRequest = await models.customRequest.findOne({
     where: {
       requestId: requestId,
+      conditions: {
+        skipPrivacyZoneScope: true,
+      },
     },
   });
 
-  if (customRequest?.conditions?.skipPrivacyZoneScope) {
+  if (customRequest) {
     return true;
   }
 

--- a/app/schemas-ui/index.ts
+++ b/app/schemas-ui/index.ts
@@ -11,6 +11,7 @@ interface Props {
   teams: Team[];
   schemas: any;
   defaultSessionSettings: GetStandardSettingsResponse;
+  bcscExcluded: boolean;
 }
 
 export const getUISchema = (props: Props) => {

--- a/app/schemas-ui/ui-gold.ts
+++ b/app/schemas-ui/ui-gold.ts
@@ -1,4 +1,4 @@
-import { isNil, uniq, get } from 'lodash';
+import { get } from 'lodash';
 import FieldProjectTeam from '@app/form-components/FieldProjectTeam';
 import ClientTypeWidget from '@app/form-components/widgets/ClientTypeWidget';
 import ClientTokenWidget from '@app/form-components/widgets/ClientTokenWidget';
@@ -43,7 +43,6 @@ const getUISchema = ({
   bcscExcluded,
 }: Props) => {
   const {
-    id,
     status,
     devIdps = [],
     environments = [],
@@ -54,19 +53,18 @@ const getUISchema = ({
     githubApproved = false,
     otpApproved = false,
   } = integration || {};
-  const isNew = isNil(id);
   const isApplied = status === 'applied';
   const disableBcscUpdateApproved = integration?.devIdps?.includes('bcservicescard') && bcServicesCardApproved;
   const disableOtpUpdateApproved = integration?.devIdps?.includes('otp') && otpApproved;
   const isSaml = integration?.protocol === 'saml';
 
   const envDisabled = isApplied ? environments?.concat() || [] : ['dev'];
-  let idpDisabled: string[] = [];
+  let idpsDisabled: { idp: string; reason: string }[] = [];
   let idpHidden: string[] = [];
   let allIdpsDisabled = false;
 
   if (bcscExcluded && !devIdps.includes('otp')) {
-    idpDisabled.push('otp');
+    idpsDisabled.push({ idp: 'otp', reason: 'Disabled as client is in bc services card exclusion list' });
   }
 
   // If applied AND approved, ALL users can only remove. Removal will reset the approval, allowing them to add again.
@@ -77,23 +75,26 @@ const getUISchema = ({
     }
     if (bceidApproved || devBceidApproved || testBceidApproved) {
       ['bceidbasic', 'bceidbusiness', 'bceidboth'].forEach((bceidIdp) => {
-        if (!devIdps.includes(bceidIdp)) idpDisabled.push(bceidIdp);
+        if (!devIdps.includes(bceidIdp)) idpsDisabled.push({ idp: bceidIdp, reason: '' });
       });
     }
     if (githubApproved) {
       ['githubpublic', 'githubbcgov'].forEach((githubIdp) => {
-        if (!devIdps.includes(githubIdp)) idpDisabled.push(githubIdp);
+        if (!devIdps.includes(githubIdp)) idpsDisabled.push({ idp: githubIdp, reason: '' });
       });
     }
     if (bcServicesCardApproved) {
-      idpDisabled.push('bcservicescard');
+      idpsDisabled.push({ idp: 'bcservicescard', reason: '' });
     }
     if (otpApproved) {
-      idpDisabled.push('otp');
+      idpsDisabled.push({ idp: 'otp', reason: '' });
     }
   }
 
-  idpDisabled = uniq(idpDisabled);
+  // remove duplicates from idpsDisabled json array
+  idpsDisabled = Array.from(new Set(idpsDisabled.map((element) => JSON.stringify(element)))).map((element) =>
+    JSON.parse(element),
+  );
 
   // Only admins or integrations already using public github can use the IDP.
   if (
@@ -107,7 +108,7 @@ const getUISchema = ({
 
   // Disabling saml for DC integrations until appending pres_req_conf_id is figured out.
   if (formData?.protocol === 'saml') {
-    idpDisabled.push('digitalcredential');
+    idpsDisabled.push({ idp: 'digitalcredential', reason: '' });
   }
 
   const includeComment = isApplied && hasAppPermission(session?.client_roles, appPermissions.ADD_REQUEST_COMMENT);
@@ -277,7 +278,7 @@ const getUISchema = ({
     devIdps: {
       'ui:disabled': allIdpsDisabled,
       'ui:widget': TooltipIDPCheckboxesWidget,
-      'ui:enumDisabled': idpDisabled,
+      'ui:idpsDisabled': idpsDisabled,
       'ui:enumHidden': idpHidden,
       'ui:enumNames': schemas[1]?.properties?.devIdps?.items?.enum.map((idp: string) => idpMap[idp]) || [],
     },

--- a/app/schemas-ui/ui-gold.ts
+++ b/app/schemas-ui/ui-gold.ts
@@ -91,10 +91,14 @@ const getUISchema = ({
     }
   }
 
-  // remove duplicates from idpsDisabled json array
-  idpsDisabled = Array.from(new Set(idpsDisabled.map((element) => JSON.stringify(element)))).map((element) =>
-    JSON.parse(element),
-  );
+  // remove duplicates from idpsDisabled json array by idp
+  const seenIdps = new Set();
+  idpsDisabled = idpsDisabled.filter((element) => {
+    const key = `${element.idp}|${element.reason}`;
+    if (seenIdps.has(key)) return false;
+    seenIdps.add(key);
+    return true;
+  });
 
   // Only admins or integrations already using public github can use the IDP.
   if (

--- a/app/schemas-ui/ui-gold.ts
+++ b/app/schemas-ui/ui-gold.ts
@@ -28,11 +28,20 @@ interface Props {
   teams: Team[];
   schemas: any;
   defaultSessionSettings: GetStandardSettingsResponse;
+  bcscExcluded: boolean;
 }
 
 const envs = environments as Environment[];
 
-const getUISchema = ({ integration, formData, session, teams, schemas, defaultSessionSettings }: Props) => {
+const getUISchema = ({
+  integration,
+  formData,
+  session,
+  teams,
+  schemas,
+  defaultSessionSettings,
+  bcscExcluded,
+}: Props) => {
   const {
     id,
     status,
@@ -55,6 +64,10 @@ const getUISchema = ({ integration, formData, session, teams, schemas, defaultSe
   let idpDisabled: string[] = [];
   let idpHidden: string[] = [];
   let allIdpsDisabled = false;
+
+  if (bcscExcluded) {
+    idpDisabled.push('otp');
+  }
 
   // If applied AND approved, ALL users can only remove. Removal will reset the approval, allowing them to add again.
   // Allowing this in one swipe really complicates things, mostly because there is one "bceidapproved" flag and not 3.

--- a/app/schemas-ui/ui-gold.ts
+++ b/app/schemas-ui/ui-gold.ts
@@ -65,7 +65,7 @@ const getUISchema = ({
   let idpHidden: string[] = [];
   let allIdpsDisabled = false;
 
-  if (bcscExcluded) {
+  if (bcscExcluded && !devIdps.includes('otp')) {
     idpDisabled.push('otp');
   }
 

--- a/app/services/request.ts
+++ b/app/services/request.ts
@@ -147,10 +147,10 @@ export const updateRequestMetadata = async (data: Integration): Promise<[Integra
   }
 };
 
-export const isRequestBcscExcluded = async (data: Integration): Promise<[boolean, null] | [null, AxiosError]> => {
+export const isRequestBcscExcluded = async (id: number): Promise<[boolean, null] | [null, AxiosError]> => {
   try {
-    const result = await instance.get(`requests/${data.id}/is-bcsc-excluded`).then((res) => res.data);
-    return [result.message, null];
+    const result = await instance.get(`requests/${id}/is-bcsc-excluded`).then((res) => res.data);
+    return [result.message === true, null];
   } catch (err: any) {
     return handleAxiosError(err);
   }

--- a/app/services/request.ts
+++ b/app/services/request.ts
@@ -146,3 +146,12 @@ export const updateRequestMetadata = async (data: Integration): Promise<[Integra
     return handleAxiosError(err);
   }
 };
+
+export const isRequestBcscExcluded = async (data: Integration): Promise<[boolean, null] | [null, AxiosError]> => {
+  try {
+    const result = await instance.get(`requests/${data.id}/is-bcsc-excluded`).then((res) => res.data);
+    return [result.message, null];
+  } catch (err: any) {
+    return handleAxiosError(err);
+  }
+};

--- a/app/shared/sequelize/models/CustomRequest.ts
+++ b/app/shared/sequelize/models/CustomRequest.ts
@@ -1,0 +1,35 @@
+const init = (sequelize: any, DataTypes: any) => {
+  const CustomRequest = sequelize.define(
+    'customRequest',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        primaryKey: true,
+        allowNull: false,
+        autoIncrement: true,
+      },
+      requestId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+      },
+      conditions: {
+        type: DataTypes.JSONB,
+        allowNull: true,
+        defaultValue: {},
+      },
+      comments: {
+        type: DataTypes.TEXT,
+        allowNull: true,
+      },
+    },
+    {
+      underscored: true,
+      associate: function (models: any) {
+        CustomRequest.belongsTo(models.request, { foreignKey: 'requestId', targetKey: 'id' });
+      },
+    },
+  );
+  return CustomRequest;
+};
+
+export default init;

--- a/app/shared/sequelize/models/models.ts
+++ b/app/shared/sequelize/models/models.ts
@@ -9,6 +9,7 @@ import UserTeam from './UserTeam';
 import RequestQueue from './RequestQueue';
 import RequestRole from './RequestRole';
 import BcscClient from './BcscClient';
+import CustomRequest from './CustomRequest';
 
 const config: any = configs[`${process.env.NODE_ENV || 'development'}`];
 
@@ -26,7 +27,7 @@ if (config.databaseUrl) {
 
 console.log('sequelize initialized', !!sequelize);
 
-[Event, Request, Team, User, UserTeam, Survey, RequestQueue, RequestRole, BcscClient].forEach((init) => {
+[Event, Request, Team, User, UserTeam, Survey, RequestQueue, RequestRole, BcscClient, CustomRequest].forEach((init) => {
   const model = init(sequelize, DataTypes);
   models[model.name] = model;
   modelNames.push(model.name);

--- a/db/src/migrations/2026.07.27T10.00.00.add-custom-requests-table.ts
+++ b/db/src/migrations/2026.07.27T10.00.00.add-custom-requests-table.ts
@@ -1,0 +1,47 @@
+import { DataTypes } from 'sequelize';
+
+export const name = '2026.07.27T10.00.00.add-custom-requests-table';
+
+// see https://sequelize.org/master/manual/naming-strategies.html
+export const up = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().createTable('custom_requests', {
+    id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      primaryKey: true,
+      defaultValue: sequelize.UUIDV4,
+      autoIncrement: true,
+    },
+    request_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      field: 'created_at',
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      field: 'updated_at',
+      allowNull: false,
+      defaultValue: DataTypes.NOW,
+    },
+    conditions: {
+      type: DataTypes.JSONB,
+      allowNull: true,
+      defaultValue: {},
+    },
+    comments: {
+      type: DataTypes.TEXT,
+      allowNull: true,
+    },
+  });
+};
+
+export const down = async ({ context: sequelize }) => {
+  await sequelize.getQueryInterface().dropTable('custom_requests');
+};
+
+export default { name, up, down };

--- a/db/src/migrations/2026.07.27T10.00.00.add-custom-requests-table.ts
+++ b/db/src/migrations/2026.07.27T10.00.00.add-custom-requests-table.ts
@@ -9,7 +9,6 @@ export const up = async ({ context: sequelize }) => {
       type: DataTypes.INTEGER,
       allowNull: false,
       primaryKey: true,
-      defaultValue: sequelize.UUIDV4,
       autoIncrement: true,
     },
     requestId: {

--- a/db/src/migrations/2026.07.27T10.00.00.add-custom-requests-table.ts
+++ b/db/src/migrations/2026.07.27T10.00.00.add-custom-requests-table.ts
@@ -12,9 +12,13 @@ export const up = async ({ context: sequelize }) => {
       defaultValue: sequelize.UUIDV4,
       autoIncrement: true,
     },
-    request_id: {
+    requestId: {
       type: DataTypes.INTEGER,
       allowNull: false,
+      field: 'request_id',
+      references: { model: 'requests', key: 'id' },
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE',
     },
     createdAt: {
       type: DataTypes.DATE,

--- a/db/src/umzug.ts
+++ b/db/src/umzug.ts
@@ -63,6 +63,7 @@ export const createMigrator = async () => {
       await import('./migrations/2025.06.17T12.31.60.add-otp-approved'),
       await import('./migrations/2025.08.22T09.00.00.create-api-usage-metrics'),
       await import('./migrations/2026.05.08T10.17.31.add-dev-test-bceid-approved'),
+      await import('./migrations/2026.07.27T10.00.00.add-custom-requests-table'),
     ],
     context: sequelize,
     storage: new SequelizeStorage({


### PR DESCRIPTION
1. Do not allow existing bcsc clients to add OTP
2. Do not assign privacy zone scope with ppid mapper to the existing bcsc clients